### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [![npm](https://img.shields.io/npm/v/oilpriceapi-mcp)](https://www.npmjs.com/package/oilpriceapi-mcp)
 [![license](https://img.shields.io/npm/l/oilpriceapi-mcp)](LICENSE)
 
+<a href="https://glama.ai/mcp/servers/OilpriceAPI/oil-price-api">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/OilpriceAPI/oil-price-api/badge" alt="OilPriceAPI MCP server" />
+</a>
+
 ## Features
 
 - **4 Tools** — get prices, market overviews, price comparisons, commodity listings


### PR DESCRIPTION
This PR adds a badge for the [OilPriceAPI](https://glama.ai/mcp/servers/OilpriceAPI/oil-price-api) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/OilpriceAPI/oil-price-api">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/OilpriceAPI/oil-price-api/badge" alt="OilPriceAPI MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new badge section to the documentation linking to an external service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->