### PR TITLE
feat: #3245 subscription + market-brief MCP tools (v2.3.0) — activates the agent ARR loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ These tools create and manage **persistent** price alerts tied to your OilPriceA
 | `opa_delete_price_alert` | Permanently delete an alert by id                                            |
 | `opa_get_alert_triggers` | Recent alert trigger activity (optionally filtered by `since`)               |
 
+### Market Brief & Subscription Tools (authenticated)
+
+The market brief gives a multi-commodity snapshot in one call. Subscriptions ("watches") are **persistent, recurring** snapshots tied to your account — the API records an event every interval, and the agent **polls** for new events via a per-user cursor (events are polled, not pushed — there is no always-on connection). These **require an API key** (`OILPRICEAPI_KEY`). A subscription differs from an alert: a watch always emits an event each interval (a running log), whereas an alert fires only on a threshold crossing. Per-tier limits apply (free: 1 watch, 3 codes, 1h minimum interval); the API returns the exact limit if exceeded.
+
+| Tool                            | Description                                                                           |
+| ------------------------------- | ------------------------------------------------------------------------------------- |
+| `opa_get_market_brief`          | Multi-commodity brief: prices, 24h changes, 1m forecasts, spreads, optional narrative |
+| `opa_create_price_subscription` | Create a persistent recurring watch (codes, interval like `5m`/`1h`/`daily`)          |
+| `opa_list_subscriptions`        | List all subscriptions on the account                                                 |
+| `opa_delete_subscription`       | Permanently delete a subscription by id                                               |
+| `opa_get_subscription_events`   | Poll for new watch events since a cursor (`since`); returns snapshots + deltas        |
+
 ## Example Questions
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "mcpName": "io.github.OilpriceAPI/mcp-server",
   "description": "The energy commodity MCP server. Real-time oil, gas, and commodity prices for Claude, Cursor, and any MCP client.",
   "type": "module",

--- a/scripts/live-smoke.mjs
+++ b/scripts/live-smoke.mjs
@@ -3,12 +3,18 @@
 /**
  * Live smoke test against the real OilPriceAPI.
  *
- * Verifies the futures path fix (v2.2.1) end-to-end:
+ * Verifies the futures path fix (v2.2.1) AND the #3245 subscription +
+ * market-brief tools (v2.3.0) end-to-end against PRODUCTION:
  *   - GET /v1/futures/ice-brent          (latest)  -> 200 + numeric front-month last_price
  *   - GET /v1/futures/ice-brent/curve    (curve)   -> 200 + curve data OR documented no-data state
+ *   - GET /v1/market-brief?codes=BRENT_CRUDE_USD   -> 200 + a numeric price (opa_get_market_brief)
+ *   - GET /v1/subscriptions               (list)   -> 200 + { data: { subscriptions: [...] } } (opa_list_subscriptions)
+ *   - POST/GET/DELETE round-trip on /v1/subscriptions (opa_create_price_subscription / events / delete)
+ *     — only when SMOKE_WRITE_SUBSCRIPTIONS=1; the created watch is cleaned up
+ *     in the SAME run so production is never littered. Off by default so the
+ *     default CI run only READS from prod.
  *
- * These are the paths the MCP tools build (opa_get_futures /
- * opa_get_futures_curve). The old v2.2.0 code hit
+ * These are the paths the MCP tools build. The old v2.2.0 code hit
  * /v1/futures/latest?contract=BZ and /v1/futures/curve?contract=BZ which
  * both 404 — there is no generic ?contract= futures route.
  *
@@ -29,6 +35,9 @@ const API_BASE =
 const KEY = process.env.OILPRICEAPI_TEST_KEY;
 const SLUG = "ice-brent";
 const RATE_LIMIT_MS = 1100; // > 1 req/sec
+// Opt-in: exercise the WRITE round-trip (create -> events -> delete) against
+// prod. Off by default so the standard CI run only reads.
+const WRITE_SUBSCRIPTIONS = process.env.SMOKE_WRITE_SUBSCRIPTIONS === "1";
 
 if (!KEY) {
   console.log(
@@ -41,16 +50,32 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function getJson(path) {
+async function request(path, { method = "GET", body, headers = {} } = {}) {
   const res = await fetch(`${API_BASE}${path}`, {
+    method,
     headers: {
       Authorization: `Bearer ${KEY}`,
       Accept: "application/json",
-      "User-Agent": "oilpriceapi-mcp-live-smoke/2.2.1",
+      "User-Agent": "oilpriceapi-mcp-live-smoke/2.3.0",
+      ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      ...headers,
     },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
   });
-  const body = await res.json().catch(() => null);
-  return { status: res.status, body };
+  const text = await res.text();
+  let parsed = null;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+  }
+  return { status: res.status, body: parsed };
+}
+
+async function getJson(path) {
+  return request(path);
 }
 
 function assert(cond, msg) {
@@ -143,6 +168,152 @@ async function main() {
   } catch (err) {
     failures++;
     console.error(`FAIL (curve): ${err.message}`);
+  }
+
+  // Space requests — API rate limit is 1 req/sec.
+  await sleep(RATE_LIMIT_MS);
+
+  // 3. Market brief — GET /v1/market-brief?codes=BRENT_CRUDE_USD
+  // This is what opa_get_market_brief builds. Require 200 + a numeric price for
+  // Brent in the structured `commodities` array (envelope: { status, data }).
+  try {
+    const { status, body } = await getJson(
+      "/v1/market-brief?codes=BRENT_CRUDE_USD",
+    );
+    assert(status === 200, `market-brief expected 200, got ${status}`);
+    const data = body && body.data;
+    assert(
+      data && Array.isArray(data.commodities) && data.commodities.length > 0,
+      `market-brief missing data.commodities: ${JSON.stringify(body)}`,
+    );
+    const brent = data.commodities.find((c) => c.code === "BRENT_CRUDE_USD");
+    assert(brent, "market-brief missing BRENT_CRUDE_USD commodity");
+    assert(
+      typeof brent.price === "number" &&
+        Number.isFinite(brent.price) &&
+        brent.price > 0,
+      `market-brief Brent price not a positive number: ${brent.price}`,
+    );
+    console.log(
+      `PASS: GET /v1/market-brief -> 200, Brent @ $${brent.price} (${brent.currency})`,
+    );
+  } catch (err) {
+    failures++;
+    console.error(`FAIL (market-brief): ${err.message}`);
+  }
+
+  await sleep(RATE_LIMIT_MS);
+
+  // 4. List subscriptions — GET /v1/subscriptions
+  // What opa_list_subscriptions builds. Require 200 + a subscriptions array
+  // (empty or populated — both valid).
+  try {
+    const { status, body } = await getJson("/v1/subscriptions");
+    assert(status === 200, `subscriptions list expected 200, got ${status}`);
+    const subs = body && body.data && body.data.subscriptions;
+    assert(
+      Array.isArray(subs),
+      `subscriptions list missing data.subscriptions[]: ${JSON.stringify(body)}`,
+    );
+    console.log(
+      `PASS: GET /v1/subscriptions -> 200, ${subs.length} subscription(s)`,
+    );
+  } catch (err) {
+    failures++;
+    console.error(`FAIL (subscriptions list): ${err.message}`);
+  }
+
+  // 5. WRITE round-trip (opt-in) — create -> poll events -> delete.
+  // Guarded behind SMOKE_WRITE_SUBSCRIPTIONS=1 so the default run never writes
+  // to prod. When enabled, the created watch is ALWAYS deleted in the same run
+  // (even if a mid-step assertion fails) so prod is not littered.
+  if (WRITE_SUBSCRIPTIONS) {
+    let createdId = null;
+    try {
+      await sleep(RATE_LIMIT_MS);
+      // Create a 1h (free-tier floor) Brent watch, stamped as MCP.
+      const created = await request("/v1/subscriptions", {
+        method: "POST",
+        body: {
+          codes: ["BRENT_CRUDE_USD"],
+          interval_seconds: 3600,
+          name: "live-smoke (auto-cleanup)",
+        },
+        headers: {
+          "X-OPA-Source": "mcp",
+          "X-OPA-Tool": "opa_create_price_subscription",
+        },
+      });
+      assert(
+        created.status === 200 || created.status === 201,
+        `create expected 200/201, got ${created.status}: ${JSON.stringify(created.body)}`,
+      );
+      createdId =
+        created.body &&
+        created.body.subscription &&
+        created.body.subscription.id;
+      assert(createdId, "create did not return a subscription id");
+      console.log(`PASS: POST /v1/subscriptions -> created watch ${createdId}`);
+
+      await sleep(RATE_LIMIT_MS);
+      // List should now include it.
+      const list = await getJson("/v1/subscriptions");
+      assert(list.status === 200, `re-list expected 200, got ${list.status}`);
+      const ids = (list.body?.data?.subscriptions ?? []).map((s) => s.id);
+      assert(
+        ids.includes(createdId),
+        "created watch not present in subsequent list",
+      );
+      console.log("PASS: created watch appears in list");
+
+      await sleep(RATE_LIMIT_MS);
+      // Events poll should 200 (likely empty until the evaluator runs).
+      const events = await getJson("/v1/subscriptions/events?since=0");
+      assert(
+        events.status === 200,
+        `events expected 200, got ${events.status}`,
+      );
+      assert(
+        events.body && Array.isArray(events.body?.data?.events),
+        `events missing data.events[]: ${JSON.stringify(events.body)}`,
+      );
+      console.log(
+        `PASS: GET /v1/subscriptions/events -> 200, ${events.body.data.events.length} event(s), cursor ${events.body.data.cursor}`,
+      );
+    } catch (err) {
+      failures++;
+      console.error(`FAIL (subscription write round-trip): ${err.message}`);
+    } finally {
+      // Always clean up the created watch so prod is not littered.
+      if (createdId) {
+        await sleep(RATE_LIMIT_MS);
+        try {
+          const del = await request(
+            `/v1/subscriptions/${encodeURIComponent(createdId)}`,
+            { method: "DELETE" },
+          );
+          if (del.status === 204 || del.status === 200) {
+            console.log(
+              `PASS: DELETE /v1/subscriptions/${createdId} -> cleaned up`,
+            );
+          } else {
+            failures++;
+            console.error(
+              `FAIL (cleanup): DELETE expected 200/204, got ${del.status} — watch ${createdId} may remain in prod`,
+            );
+          }
+        } catch (err) {
+          failures++;
+          console.error(
+            `FAIL (cleanup): ${err.message} — watch ${createdId} may remain in prod`,
+          );
+        }
+      }
+    }
+  } else {
+    console.log(
+      "SKIP: subscription WRITE round-trip (set SMOKE_WRITE_SUBSCRIPTIONS=1 to exercise create/delete against prod).",
+    );
   }
 
   if (failures > 0) {

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.OilpriceAPI/mcp-server",
-  "description": "The energy commodity MCP server. 21 tools: 17 read tools for real-time spot prices, historical data, futures curves, marine fuels, rig counts, diesel by state, OPEC production, storage levels, price forecasts, EIA oil inventories, well permits, and refining spreads, plus 4 authenticated tools to create, list, and delete persistent price alerts and read trigger activity. 70+ commodities with natural language queries.",
+  "description": "The energy commodity MCP server. 26 tools: 17 read tools for real-time spot prices, historical data, futures curves, marine fuels, rig counts, diesel by state, OPEC production, storage levels, price forecasts, EIA oil inventories, well permits, and refining spreads; 4 authenticated tools to create, list, and delete persistent price alerts and read trigger activity; plus 5 authenticated agent tools for multi-commodity market briefs and persistent recurring price subscriptions (create/list/delete/poll). 70+ commodities with natural language queries.",
   "repository": {
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"
   },
-  "version": "2.2.1",
+  "version": "2.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "oilpriceapi-mcp",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -4,6 +4,9 @@ import {
   resolveStateCode,
   formatPrice,
   makeApiRequest,
+  makeAuthRequest,
+  resolveIntervalSeconds,
+  SUBSCRIPTION_INTERVAL_PRESETS,
   COMMODITY_ALIASES,
   COMMODITY_INFO,
 } from "../index.js";
@@ -476,5 +479,140 @@ describe("COMMODITY_INFO", () => {
     expect(info).toBeDefined();
     expect(info.name).toBe("Gold");
     expect(info.unit).toBe("troy oz");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveIntervalSeconds (#3245 subscription tools)
+// ---------------------------------------------------------------------------
+
+describe("resolveIntervalSeconds", () => {
+  it("maps friendly presets to seconds", () => {
+    expect(resolveIntervalSeconds("5m")).toBe(300);
+    expect(resolveIntervalSeconds("1h")).toBe(3600);
+    expect(resolveIntervalSeconds("hourly")).toBe(3600);
+    expect(resolveIntervalSeconds("daily")).toBe(86400);
+    expect(resolveIntervalSeconds("1d")).toBe(86400);
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(resolveIntervalSeconds("  5M ")).toBe(300);
+    expect(resolveIntervalSeconds("DAILY")).toBe(86400);
+  });
+
+  it("treats a bare integer as seconds", () => {
+    expect(resolveIntervalSeconds("3600")).toBe(3600);
+    expect(resolveIntervalSeconds("90")).toBe(90);
+  });
+
+  it("parses <n><unit> shorthand", () => {
+    expect(resolveIntervalSeconds("10m")).toBe(600);
+    expect(resolveIntervalSeconds("2h")).toBe(7200);
+    expect(resolveIntervalSeconds("3d")).toBe(259200);
+    expect(resolveIntervalSeconds("45s")).toBe(45);
+  });
+
+  it("returns null for invalid or non-positive inputs", () => {
+    expect(resolveIntervalSeconds("nonsense")).toBeNull();
+    expect(resolveIntervalSeconds("0")).toBeNull();
+    expect(resolveIntervalSeconds("0m")).toBeNull();
+    expect(resolveIntervalSeconds("")).toBeNull();
+  });
+
+  it("preset table covers the documented tier floors", () => {
+    // free 1h, developer 30m, starter 15m, professional 5m, scale 1m
+    expect(SUBSCRIPTION_INTERVAL_PRESETS["1h"]).toBe(3600);
+    expect(SUBSCRIPTION_INTERVAL_PRESETS["30m"]).toBe(1800);
+    expect(SUBSCRIPTION_INTERVAL_PRESETS["15m"]).toBe(900);
+    expect(SUBSCRIPTION_INTERVAL_PRESETS["5m"]).toBe(300);
+    expect(SUBSCRIPTION_INTERVAL_PRESETS["1m"]).toBe(60);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeAuthRequest — POST body + custom attribution headers
+// ---------------------------------------------------------------------------
+
+describe("makeAuthRequest - request shaping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("POSTs a JSON body and merges custom headers (X-OPA-Source/Tool)", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ subscription: { id: "abc" } }),
+    });
+
+    const result = await makeAuthRequest(
+      "/v1/subscriptions",
+      {
+        method: "POST",
+        body: { codes: ["BRENT_CRUDE_USD"], interval_seconds: 3600 },
+        headers: {
+          "X-OPA-Source": "mcp",
+          "X-OPA-Tool": "opa_create_price_subscription",
+        },
+      },
+      mockFetch as typeof fetch,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(init.headers["X-OPA-Source"]).toBe("mcp");
+    expect(init.headers["X-OPA-Tool"]).toBe("opa_create_price_subscription");
+    expect(JSON.parse(init.body)).toEqual({
+      codes: ["BRENT_CRUDE_USD"],
+      interval_seconds: 3600,
+    });
+  });
+
+  it("parses the { status, data } envelope on a GET events poll", async () => {
+    const payload = {
+      status: "success",
+      data: { cursor: 7, has_more: false, events: [] },
+    };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    });
+
+    const result = await makeAuthRequest(
+      "/v1/subscriptions/events?since=3",
+      {},
+      mockFetch as typeof fetch,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.body).toEqual(payload);
+  });
+
+  it("surfaces a non-ok status with the parsed error body (422 limit)", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: async () =>
+        JSON.stringify({
+          error: "WATCH_LIMIT",
+          message: "Your plan allows up to 1 active watches. Upgrade for more.",
+        }),
+    });
+
+    const result = await makeAuthRequest(
+      "/v1/subscriptions",
+      { method: "POST", body: { codes: ["WTI_USD"], interval_seconds: 3600 } },
+      mockFetch as typeof fetch,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(422);
+    expect((result.body as { error: string }).error).toBe("WATCH_LIMIT");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,29 @@
 #!/usr/bin/env node
 
 /**
- * OilPriceAPI MCP Server v2.2.1
+ * OilPriceAPI MCP Server v2.3.0
  *
  * The energy commodity MCP server. Real-time oil, gas, and commodity prices
  * for Claude, Cursor, VS Code, and any MCP-compatible client.
  *
- * 17 read-only tools (opa_ prefixed): prices, history, futures, marine fuels,
- * rig counts, drilling, diesel-by-state, storage, OPEC production, forecasts,
- * EIA oil inventories, well permits, refining spreads.
+ * 26 tools total (opa_ prefixed):
+ *
+ * 17 read-only tools: prices, history, futures, marine fuels, rig counts,
+ * drilling, diesel-by-state, storage, OPEC production, forecasts, EIA oil
+ * inventories, well permits, refining spreads.
  *
  * 4 authenticated price-alert tools (opa_*_price_alert / opa_get_alert_triggers):
  * create/list/delete persistent price alerts tied to the user's account and read
  * recent trigger activity. These wrap the existing /v1/alerts engine and REQUIRE
  * an API key (OILPRICEAPI_KEY).
+ *
+ * 5 authenticated agent-subscription + market-brief tools (#3245 Phase 2):
+ * opa_get_market_brief (multi-commodity structured + narrative summary) and
+ * opa_create_price_subscription / opa_list_subscriptions /
+ * opa_delete_subscription / opa_get_subscription_events. Subscriptions
+ * ("watches") are PERSISTENT, account-tied, recurring snapshots polled via a
+ * per-user cursor — they REQUIRE an API key. These wrap /v1/market-brief and
+ * /v1/subscriptions.
  *
  * @see https://oilpriceapi.com
  * @see https://modelcontextprotocol.io
@@ -26,7 +36,7 @@ import { z } from "zod";
 // API Configuration
 const API_BASE =
   process.env.OILPRICEAPI_BASE_URL || "https://api.oilpriceapi.com";
-export const USER_AGENT = "oilpriceapi-mcp/2.2.1";
+export const USER_AGENT = "oilpriceapi-mcp/2.3.0";
 
 // Get API key from environment
 const API_KEY = process.env.OILPRICEAPI_KEY || process.env.OIL_PRICE_API_KEY;
@@ -424,7 +434,7 @@ interface DrillingData {
 
 const server = new McpServer({
   name: "oilpriceapi",
-  version: "2.2.1",
+  version: "2.3.0",
 });
 
 // ---------------------------------------------------------------------------
@@ -662,10 +672,14 @@ export interface AuthRequestResult {
  */
 export async function makeAuthRequest(
   endpoint: string,
-  options: { method?: string; body?: unknown } = {},
+  options: {
+    method?: string;
+    body?: unknown;
+    headers?: Record<string, string>;
+  } = {},
   fetchFn: typeof fetch = fetch,
 ): Promise<AuthRequestResult> {
-  const { method = "GET", body } = options;
+  const { method = "GET", body, headers: extraHeaders } = options;
 
   const headers: Record<string, string> = {
     "User-Agent": USER_AGENT,
@@ -675,6 +689,10 @@ export async function makeAuthRequest(
   };
   if (body !== undefined) {
     headers["Content-Type"] = "application/json";
+  }
+  // Caller-supplied headers (e.g. MCP attribution: X-OPA-Source / X-OPA-Tool).
+  if (extraHeaders) {
+    Object.assign(headers, extraHeaders);
   }
 
   try {
@@ -747,6 +765,60 @@ export const ALERT_OPERATORS = [
   "greater_than_or_equal",
   "less_than_or_equal",
 ] as const;
+
+// ---------------------------------------------------------------------------
+// Subscription ("watch") interval mapping (#3245 Phase 2)
+//
+// The /v1/subscriptions API stores the snapshot cadence as `interval_seconds`
+// (an integer), and enforces a per-tier interval FLOOR server-side
+// (free 3600s/1h → developer 1800s/30m → starter 900s/15m → professional
+// 300s/5m → scale 60s/1m). We let agents pass a friendly `interval` like "5m",
+// "1h", or "daily" and translate it to seconds here. A bare integer string is
+// treated as seconds. If the chosen interval is below the caller's tier floor,
+// the API returns a 422 with the exact minimum — we surface that message.
+// ---------------------------------------------------------------------------
+
+export const SUBSCRIPTION_INTERVAL_PRESETS: Record<string, number> = {
+  "1m": 60,
+  "5m": 300,
+  "15m": 900,
+  "30m": 1800,
+  "1h": 3600,
+  hourly: 3600,
+  "6h": 21600,
+  "12h": 43200,
+  daily: 86400,
+  "1d": 86400,
+};
+
+/**
+ * Translate a friendly interval ("5m" / "1h" / "daily") or a bare seconds
+ * value ("300") into interval_seconds for POST /v1/subscriptions. Returns null
+ * for anything unrecognized so the caller can return an actionable error.
+ */
+export function resolveIntervalSeconds(input: string): number | null {
+  const normalized = input.toLowerCase().trim();
+
+  const preset = SUBSCRIPTION_INTERVAL_PRESETS[normalized];
+  if (preset) return preset;
+
+  // Bare integer (seconds), e.g. "300".
+  if (/^\d+$/.test(normalized)) {
+    const seconds = parseInt(normalized, 10);
+    return seconds > 0 ? seconds : null;
+  }
+
+  // "<n><unit>" shorthand, e.g. "10m", "2h", "3d".
+  const match = normalized.match(/^(\d+)\s*(s|m|h|d)$/);
+  if (match) {
+    const n = parseInt(match[1], 10);
+    if (n <= 0) return null;
+    const unitSeconds = { s: 1, m: 60, h: 3600, d: 86400 }[match[2]];
+    return unitSeconds ? n * unitSeconds : null;
+  }
+
+  return null;
+}
 
 /**
  * Resolve a US state name or abbreviation to a 2-letter code.
@@ -1920,6 +1992,490 @@ server.tool(
 );
 
 // =========================================================================
+// AGENT SUBSCRIPTION + MARKET BRIEF TOOLS (#3245 Phase 2)
+//
+// These activate the agent loop: a multi-commodity market brief plus
+// PERSISTENT, recurring "watches" (subscriptions) that the API snapshots every
+// interval. Agents POLL for new events via a per-user cursor — there is NO
+// always-on connection; nothing is pushed to the agent.
+//
+//   - opa_get_market_brief         GET    /v1/market-brief
+//   - opa_create_price_subscription POST  /v1/subscriptions
+//   - opa_list_subscriptions       GET    /v1/subscriptions
+//   - opa_delete_subscription      DELETE /v1/subscriptions/:id
+//   - opa_get_subscription_events  GET    /v1/subscriptions/events?since=<seq>
+//
+// Subscriptions are account-scoped and REQUIRE an API key. Per-tier limits
+// (max active watches, interval floor, codes per watch) are enforced
+// server-side; the API returns a 422 with the exact limit/minimum, which we
+// surface verbatim.
+// =========================================================================
+
+interface BriefCommodity {
+  code?: string;
+  name?: string;
+  price?: number;
+  currency?: string;
+  unit?: string;
+  change_24h_pct?: number | null;
+  change_24h_abs?: number | null;
+  as_of?: string;
+  stale?: boolean;
+  forecast_1m?: {
+    point?: number;
+    low?: number;
+    high?: number;
+    confidence?: number;
+  };
+}
+
+interface BriefData {
+  as_of?: string;
+  codes?: string[];
+  commodities?: BriefCommodity[];
+  spreads?: Array<{
+    pair?: string;
+    label?: string;
+    value?: number;
+    currency?: string;
+  }>;
+  summary?: string;
+  context?: {
+    disruptions?: Array<{ title?: string; severity?: string; region?: string }>;
+    top_indicators?: Array<{
+      code?: string;
+      value?: number;
+      change_pct?: number | null;
+    }>;
+  };
+}
+
+interface WatchRecord {
+  id?: string;
+  name?: string | null;
+  codes?: string[];
+  interval_seconds?: number;
+  status?: string;
+  deliver_webhook?: boolean;
+  source?: string;
+  tool_name?: string | null;
+  last_evaluated_at?: string | null;
+  next_run_at?: string | null;
+  created_at?: string | null;
+}
+
+function describeInterval(seconds?: number): string {
+  if (!seconds || seconds <= 0) return "n/a";
+  if (seconds % 86400 === 0) return `${seconds / 86400}d`;
+  if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+  if (seconds % 60 === 0) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}
+
+function formatWatchLine(w: WatchRecord): string {
+  const codes = Array.isArray(w.codes) ? w.codes.join(", ") : "—";
+  const every = describeInterval(w.interval_seconds);
+  const status = w.status || "active";
+  return (
+    `- **${w.name || codes}** (id: \`${w.id}\`) — ${codes}, every ${every}, ${status}` +
+    (w.next_run_at ? `, next run ${w.next_run_at}` : "")
+  );
+}
+
+server.tool(
+  "opa_get_market_brief",
+  "Get a multi-commodity market brief: latest spot prices, 24h changes, " +
+    "1-month forecasts (for Brent/WTI/Natural Gas), and notable spreads — for " +
+    "several commodities in ONE call. Use when the user wants a market snapshot, " +
+    "morning brief, or an at-a-glance read across multiple commodities. Set " +
+    "`narrative: true` to also get a plain-English summary plus market context " +
+    "(active supply disruptions, key economic indicators). Accepts natural " +
+    "language ('brent', 'us gas') or API codes. REQUIRES an API key " +
+    "(OILPRICEAPI_KEY); counts as 1 request. Per-tier code limits apply (free: 3 " +
+    "codes). For a single price use opa_get_price; for ongoing recurring " +
+    "monitoring use opa_create_price_subscription.",
+  {
+    codes: z
+      .array(z.string())
+      .min(1)
+      .describe(
+        "Commodity names or codes to include (e.g., ['brent', 'wti'] or " +
+          "['BRENT_CRUDE_USD', 'NATURAL_GAS_USD']). Free tier allows up to 3.",
+      ),
+    narrative: z
+      .boolean()
+      .optional()
+      .describe(
+        "If true, also include a plain-English summary + market context " +
+          "(disruptions, indicators). Default: false (structured data only).",
+      ),
+  },
+  async ({ codes, narrative }) => {
+    const keyErr = requireApiKey();
+    if (keyErr) return keyErr;
+
+    const resolvedCodes: string[] = [];
+    const unresolved: string[] = [];
+    for (const c of codes) {
+      const r = resolveCommodityCode(c);
+      if (r) resolvedCodes.push(r);
+      else unresolved.push(c);
+    }
+
+    if (resolvedCodes.length === 0) {
+      return errorResult(
+        `None of the requested commodities were recognized: ${unresolved.join(", ")}. ` +
+          "Use opa_list_commodities to see valid codes.",
+      );
+    }
+
+    const params = new URLSearchParams();
+    params.set("codes", resolvedCodes.join(","));
+    if (narrative) params.set("narrative", "true");
+
+    const result = await makeAuthRequest(
+      `/v1/market-brief?${params.toString()}`,
+    );
+    if (!result.ok) {
+      return errorResult(alertHttpError(result, "get the market brief"));
+    }
+
+    const envelope = result.body as ApiResponse<BriefData> | null;
+    const data = envelope?.data;
+    if (!data || !Array.isArray(data.commodities)) {
+      return errorResult(
+        "The market brief returned no data. Try again in a moment.",
+      );
+    }
+
+    const sections = ["# Market Brief\n"];
+    if (data.as_of) sections.push(`_As of ${data.as_of}_\n`);
+
+    for (const c of data.commodities) {
+      const sym =
+        c.currency === "EUR"
+          ? "€"
+          : c.currency === "GBP" || c.currency === "GBp"
+            ? "£"
+            : "$";
+      const price =
+        typeof c.price === "number" ? `${sym}${c.price.toFixed(2)}` : "n/a";
+      let line = `- **${c.name || c.code}**: ${price}`;
+      if (typeof c.change_24h_pct === "number") {
+        const sign = c.change_24h_pct >= 0 ? "+" : "";
+        line += ` (${sign}${c.change_24h_pct.toFixed(2)}% 24h)`;
+      }
+      if (c.stale) line += " ⚠️ stale";
+      if (c.forecast_1m && typeof c.forecast_1m.point === "number") {
+        line += ` — 1m forecast ~${sym}${c.forecast_1m.point.toFixed(2)}`;
+      }
+      sections.push(line);
+    }
+
+    if (Array.isArray(data.spreads) && data.spreads.length > 0) {
+      sections.push("\n## Spreads");
+      for (const s of data.spreads) {
+        const sym =
+          s.currency === "EUR" ? "€" : s.currency === "GBP" ? "£" : "$";
+        sections.push(
+          `- **${s.label || s.pair}**: ${sym}${typeof s.value === "number" ? s.value.toFixed(2) : "n/a"}`,
+        );
+      }
+    }
+
+    if (data.summary) {
+      sections.push(`\n## Summary\n${data.summary}`);
+    }
+
+    if (data.context) {
+      const disruptions = data.context.disruptions ?? [];
+      if (disruptions.length > 0) {
+        sections.push("\n## Active Disruptions");
+        for (const d of disruptions) {
+          sections.push(
+            `- ${d.title}${d.severity ? ` (${d.severity})` : ""}${d.region ? ` — ${d.region}` : ""}`,
+          );
+        }
+      }
+    }
+
+    if (unresolved.length > 0) {
+      sections.push(
+        `\n_Note: skipped unrecognized commodities: ${unresolved.join(", ")}._`,
+      );
+    }
+
+    sections.push(`\n_Data from [OilPriceAPI](https://oilpriceapi.com)_`);
+    return textResult(sections.join("\n"));
+  },
+);
+
+server.tool(
+  "opa_create_price_subscription",
+  "Create a PERSISTENT, recurring price subscription (a 'watch') tied to the " +
+    "user's OilPriceAPI account. The API snapshots the watched commodities every " +
+    "`interval` and records an event each time — so the agent can come back later " +
+    "and poll for what changed via opa_get_subscription_events. Use when the user " +
+    "wants ONGOING monitoring of one or more commodities (e.g. 'keep watching " +
+    "Brent and WTI every hour'). This is different from a price alert: a watch " +
+    "ALWAYS emits an event every interval (a running log), whereas an alert only " +
+    "fires when a threshold is crossed. REQUIRES an API key (OILPRICEAPI_KEY) — " +
+    "this writes to the user's account. Events are POLLED, not pushed: there is " +
+    "no always-on connection. Manage watches with opa_list_subscriptions and " +
+    "opa_delete_subscription. Per-tier limits apply (free: 1 watch, 3 codes, 1h " +
+    "minimum interval); the API returns the exact limit if exceeded.",
+  {
+    codes: z
+      .array(z.string())
+      .min(1)
+      .describe(
+        "Commodity names or codes to watch (e.g., ['brent', 'wti'] or " +
+          "['BRENT_CRUDE_USD']). Free tier allows up to 3 codes per watch.",
+      ),
+    interval: z
+      .string()
+      .describe(
+        "How often to snapshot: a friendly interval like '5m', '1h', '6h', " +
+          "'daily', or a bare number of seconds ('3600'). The minimum allowed " +
+          "interval depends on the plan (free: 1h). If below the floor the API " +
+          "returns the exact minimum.",
+      ),
+    name: z
+      .string()
+      .optional()
+      .describe(
+        "Optional human-readable label for the watch (e.g., 'Crude desk hourly').",
+      ),
+  },
+  async ({ codes, interval, name }) => {
+    const keyErr = requireApiKey();
+    if (keyErr) return keyErr;
+
+    const intervalSeconds = resolveIntervalSeconds(interval);
+    if (intervalSeconds === null) {
+      return errorResult(
+        `'${interval}' is not a valid interval. Use a friendly value like '5m', ` +
+          "'1h', '6h', 'daily', or a number of seconds (e.g. '3600').",
+      );
+    }
+
+    const resolvedCodes: string[] = [];
+    const unresolved: string[] = [];
+    for (const c of codes) {
+      const r = resolveCommodityCode(c);
+      if (r) resolvedCodes.push(r);
+      else unresolved.push(c);
+    }
+    if (resolvedCodes.length === 0) {
+      return errorResult(
+        `None of the requested commodities were recognized: ${unresolved.join(", ")}. ` +
+          "Use opa_list_commodities to see valid codes.",
+      );
+    }
+
+    const subscription: Record<string, unknown> = {
+      codes: resolvedCodes,
+      interval_seconds: intervalSeconds,
+    };
+    if (name) subscription.name = name;
+
+    // Attribution: stamp this as an MCP-created watch via the dedicated headers
+    // the API reads (X-OPA-Source / X-OPA-Tool) for MCP funnel analytics.
+    const result = await makeAuthRequest("/v1/subscriptions", {
+      method: "POST",
+      body: subscription,
+      headers: {
+        "X-OPA-Source": "mcp",
+        "X-OPA-Tool": "opa_create_price_subscription",
+      },
+    });
+
+    if (!result.ok) {
+      return errorResult(
+        alertHttpError(result, "create the price subscription"),
+      );
+    }
+
+    const created = (result.body as { subscription?: WatchRecord } | null)
+      ?.subscription;
+    let text = "# Price Subscription Created\n\n";
+    text += created
+      ? formatWatchLine(created)
+      : `- Watching ${resolvedCodes.join(", ")} every ${describeInterval(intervalSeconds)}`;
+    text +=
+      "\n\nThis is a PERSISTENT, recurring watch. The API snapshots these " +
+      "commodities each interval and records an event. Poll for new events with " +
+      "`opa_get_subscription_events` (events are polled, not pushed — there is no " +
+      "always-on connection). List or remove watches with `opa_list_subscriptions` " +
+      "and `opa_delete_subscription`.";
+    if (unresolved.length > 0) {
+      text += `\n\n_Note: skipped unrecognized commodities: ${unresolved.join(", ")}._`;
+    }
+    text += `\n\n_Data from [OilPriceAPI](https://oilpriceapi.com)_`;
+    return textResult(text);
+  },
+);
+
+server.tool(
+  "opa_list_subscriptions",
+  "List all PERSISTENT price subscriptions ('watches') on the user's " +
+    "OilPriceAPI account. Use when the user asks what they're monitoring, or to " +
+    "find a watch's id before deleting it. Each watch is a recurring, " +
+    "account-tied snapshot job. REQUIRES an API key (OILPRICEAPI_KEY). No " +
+    "parameters needed.",
+  {},
+  async () => {
+    const keyErr = requireApiKey();
+    if (keyErr) return keyErr;
+
+    const result = await makeAuthRequest("/v1/subscriptions");
+    if (!result.ok) {
+      return errorResult(alertHttpError(result, "list subscriptions"));
+    }
+
+    const watches =
+      (result.body as { subscriptions?: WatchRecord[] } | null)
+        ?.subscriptions ?? [];
+
+    if (watches.length === 0) {
+      return textResult(
+        "No price subscriptions are set up on this account yet. Use " +
+          "`opa_create_price_subscription` to create a recurring watch.",
+      );
+    }
+
+    const sections = [`# Price Subscriptions (${watches.length})\n`];
+    for (const w of watches) sections.push(formatWatchLine(w));
+    sections.push(`\n_Data from [OilPriceAPI](https://oilpriceapi.com)_`);
+    return textResult(sections.join("\n"));
+  },
+);
+
+server.tool(
+  "opa_delete_subscription",
+  "Permanently delete a price subscription ('watch') from the user's " +
+    "OilPriceAPI account by id. Use when the user wants to stop/cancel/remove an " +
+    "ongoing watch. Get the id from opa_list_subscriptions first. This " +
+    "permanently removes the recurring watch (and its event history) from the " +
+    "account. REQUIRES an API key (OILPRICEAPI_KEY).",
+  {
+    id: z
+      .string()
+      .describe(
+        "The id of the subscription to delete (a UUID, as returned by " +
+          "opa_list_subscriptions or opa_create_price_subscription).",
+      ),
+  },
+  async ({ id }) => {
+    const keyErr = requireApiKey();
+    if (keyErr) return keyErr;
+
+    const result = await makeAuthRequest(
+      `/v1/subscriptions/${encodeURIComponent(id)}`,
+      { method: "DELETE" },
+    );
+
+    if (result.status === 404) {
+      return errorResult(
+        `No subscription found with id \`${id}\` on this account. Use ` +
+          "opa_list_subscriptions to see valid ids.",
+      );
+    }
+    if (!result.ok) {
+      return errorResult(alertHttpError(result, "delete the subscription"));
+    }
+
+    return textResult(
+      `Price subscription \`${id}\` was permanently deleted from the user's account.`,
+    );
+  },
+);
+
+server.tool(
+  "opa_get_subscription_events",
+  "Poll for new subscription events — the recurring snapshots recorded by the " +
+    "user's watches. Use this to catch up on what changed since the last poll: " +
+    "pass the `since` cursor (the seq number) returned by the previous call to " +
+    "get only newer events. Events are POLLED, not pushed — there is no always-on " +
+    "connection, so call this periodically to stay current. Each event carries a " +
+    "price snapshot plus per-code deltas vs the prior snapshot. The returned " +
+    "`cursor` is what you pass as `since` next time. REQUIRES an API key " +
+    "(OILPRICEAPI_KEY). This poll does NOT count against the monthly request " +
+    "quota.",
+  {
+    since: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Cursor: only return events with a seq greater than this. Use the " +
+          "`cursor` from the previous call. Omit (or 0) to get the earliest " +
+          "available events.",
+      ),
+  },
+  async ({ since }) => {
+    const keyErr = requireApiKey();
+    if (keyErr) return keyErr;
+
+    const params = new URLSearchParams();
+    if (typeof since === "number") params.set("since", String(since));
+    const qs = params.toString();
+
+    const result = await makeAuthRequest(
+      `/v1/subscriptions/events${qs ? `?${qs}` : ""}`,
+    );
+    if (!result.ok) {
+      return errorResult(alertHttpError(result, "poll subscription events"));
+    }
+
+    const envelope = result.body as ApiResponse<{
+      cursor?: number;
+      has_more?: boolean;
+      events?: Array<{
+        id?: string;
+        seq?: number;
+        watch_id?: string;
+        observed_at?: string;
+        snapshot?: Record<string, unknown>;
+        deltas?: Record<string, unknown>;
+      }>;
+    }> | null;
+
+    const data = envelope?.data;
+    const events = data?.events ?? [];
+    const cursor = data?.cursor ?? since ?? 0;
+
+    if (events.length === 0) {
+      return textResult(
+        `No new subscription events since cursor ${since ?? 0}. Cursor is ${cursor}. ` +
+          "Poll again later for new snapshots.",
+      );
+    }
+
+    const sections = [`# Subscription Events (${events.length})\n`];
+    for (const e of events) {
+      sections.push(
+        `## Event seq ${e.seq}${e.observed_at ? ` — ${e.observed_at}` : ""} (watch \`${e.watch_id}\`)`,
+      );
+      sections.push("```json");
+      sections.push(
+        JSON.stringify({ snapshot: e.snapshot, deltas: e.deltas }, null, 2),
+      );
+      sections.push("```");
+    }
+    sections.push(
+      `\n**Next cursor**: \`${cursor}\`${data?.has_more ? " (more events available — poll again)" : ""}`,
+    );
+    sections.push(
+      "\n_Pass the next cursor as `since` on your next poll to get only newer events._",
+    );
+    sections.push(`\n_Data from [OilPriceAPI](https://oilpriceapi.com)_`);
+    return textResult(sections.join("\n"));
+  },
+);
+
+// =========================================================================
 // RESOURCES — subscribable price snapshots + dynamic template
 // =========================================================================
 
@@ -2186,7 +2742,7 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("OilPriceAPI MCP Server v2.2.1 running on stdio");
+  console.error("OilPriceAPI MCP Server v2.3.0 running on stdio");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Wires the OilPriceAPI MCP server to the now-LIVE #3245 endpoints, activating the agent loop: agents can pull a multi-commodity market brief and create **persistent, account-tied, recurring** price subscriptions (watches), then **poll** for events via a per-user cursor.

## Tools added (5 → 26 total)

All `opa_`-prefixed, zod schemas, agent-facing descriptions, reusing `makeAuthRequest` for writes:

| Tool | Live endpoint | Notes |
| --- | --- | --- |
| `opa_get_market_brief(codes[], narrative?)` | `GET /v1/market-brief` | Multi-commodity prices, 24h change, 1m forecast, spreads; `narrative` adds summary + context. Counts as 1 request. |
| `opa_create_price_subscription(codes[], interval, name?)` | `POST /v1/subscriptions` | Friendly `interval` (`5m`/`1h`/`daily`/seconds) → `interval_seconds`. Stamps `X-OPA-Source: mcp`, `X-OPA-Tool: opa_create_price_subscription`. |
| `opa_list_subscriptions()` | `GET /v1/subscriptions` | |
| `opa_delete_subscription(id)` | `DELETE /v1/subscriptions/:id` | |
| `opa_get_subscription_events(since?)` | `GET /v1/subscriptions/events?since=<seq>` | Per-user cursor poll; does not burn the request quota. |

Each description makes clear to an agent that subscriptions are **persistent recurring watches** (a running log, unlike threshold alerts), **require an API key**, and that events are **polled** (no always-on connection). Per-tier limits (watch count, interval floor, codes-per-watch) are enforced server-side; the API returns the exact limit/minimum, surfaced verbatim.

## Contracts confirmed from the deployed controllers

Read on `origin/main` (just deployed): `V1::MarketBriefController`, `V1::SubscriptionsController`, the `Watch` model, and `ApiLimits`. Interval floors: free 1h → developer 30m → starter 15m → professional 5m → scale 1m. Create/list/events response shapes (`{ status, data: { subscriptions: [...] } }`, `{ subscription: {...} }`, `{ cursor, has_more, events: [...] }`) match what the tools parse.

## Live test approach (endpoints are LIVE)

`scripts/live-smoke.mjs` (uses `OILPRICEAPI_TEST_KEY`, skips cleanly if absent, spaces calls ≥1.1s for the 1 req/sec limit):
- **Read (default, runs in CI):** asserts `GET /v1/market-brief?codes=BRENT_CRUDE_USD` → 200 + numeric Brent price; `GET /v1/subscriptions` → 200 + array.
- **Write (opt-in `SMOKE_WRITE_SUBSCRIPTIONS=1`):** create → list → poll events → **delete in the same run** (cleanup in a `finally`, so prod is never littered). Off by default.

Verified locally against production (read-only): Brent @ $80.38 via market-brief, `GET /v1/subscriptions` → 200 (empty). Write tools are unit-tested with mocks (request shaping, header merge, 422 limit handling).

## Gates
- `npm run build` clean
- `npm test` green (104 tests; +17 new: interval mapping + auth request shaping)
- stdio smoke (initialize + tools/list): serverInfo `v2.3.0`, 26 tools, all 5 new tools present

## Version + docs
Bumped 2.2.1 → **2.3.0** (src version const + serverInfo + `package.json` + `server.json`), README tool list + count (26), and the header comment.

> Merging + cutting the v2.3.0 release tag publishes to npm via OIDC trusted publishing. (Release tag intentionally NOT cut in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Market Brief functionality to retrieve multi-commodity market snapshots
  * Added Subscription tools: create watched price subscriptions, list existing subscriptions, delete subscriptions, and poll subscription events with cursor-based polling
  
* **Documentation**
  * Updated documentation with Market Brief and Subscription tools reference and configuration requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->