### PR TITLE
fix: registry-valid server.json description + length guard in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,14 @@ jobs:
             exit 1
           fi
           echo "Version check OK: $PKG"
+          # Registry rejects description > 100 chars (422) — the silent killer
+          # that kept 2.3.0 unpublished. Fail fast here instead.
+          DLEN=$(jq -r '.description | length' server.json)
+          if [ "$DLEN" -gt 100 ]; then
+            echo "::error::server.json description is $DLEN chars; registry max is 100"
+            exit 1
+          fi
+          echo "Description length OK: $DLEN"
 
       - name: Install mcp-publisher
         run: |

--- a/.github/workflows/registry-backfill.yml
+++ b/.github/workflows/registry-backfill.yml
@@ -30,6 +30,14 @@ jobs:
             exit 1
           fi
           echo "Version check OK: $PKG"
+          # Registry rejects description > 100 chars (422) — the silent killer
+          # that kept 2.3.0 unpublished. Fail fast here instead.
+          DLEN=$(jq -r '.description | length' server.json)
+          if [ "$DLEN" -gt 100 ]; then
+            echo "::error::server.json description is $DLEN chars; registry max is 100"
+            exit 1
+          fi
+          echo "Description length OK: $DLEN"
 
       - name: Verify version exists on npm (registry must never lead npm)
         run: |

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.OilpriceAPI/mcp-server",
-  "description": "The energy commodity MCP server. 26 tools: 17 read tools for real-time spot prices, historical data, futures curves, marine fuels, rig counts, diesel by state, OPEC production, storage levels, price forecasts, EIA oil inventories, well permits, and refining spreads; 4 authenticated tools to create, list, and delete persistent price alerts and read trigger activity; plus 5 authenticated agent tools for multi-commodity market briefs and persistent recurring price subscriptions (create/list/delete/poll). 70+ commodities with natural language queries.",
+  "description": "Real-time oil, gas & commodity prices. 26 tools: spot, history, futures, alerts, market briefs.",
   "repository": {
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"


### PR DESCRIPTION
Unblocks #14.

Backfill run 28616963957 revealed the actual root cause of the registry staleness: the registry validates `description <= 100` chars (422 otherwise), and server.json's description was ~570 chars. So every manual publish attempt since the description was expanded would have failed the same way.

- `server.json`: description shortened to 95 chars (full tool detail remains in the README and npm description)
- both workflows: fail fast with a clear error if description exceeds 100 chars

Verification: merge → re-run `registry-backfill` → registry shows 2.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)