### PR TITLE
fix: shorten server.json description to <=100 chars (unblocks MCP registry publish)

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.OilpriceAPI/mcp-server",
-  "description": "The energy commodity MCP server. 26 tools: 17 read tools for real-time spot prices, historical data, futures curves, marine fuels, rig counts, diesel by state, OPEC production, storage levels, price forecasts, EIA oil inventories, well permits, and refining spreads; 4 authenticated tools to create, list, and delete persistent price alerts and read trigger activity; plus 5 authenticated agent tools for multi-commodity market briefs and persistent recurring price subscriptions (create/list/delete/poll). 70+ commodities with natural language queries.",
+  "description": "Real-time oil, gas & commodity prices via MCP: 26 tools, 70+ commodities, natural-language queries",
   "repository": {
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"


### PR DESCRIPTION
## Problem

The MCP registry publish fails validation — **HTTP 422** from the registry:
```
"detail":"validation failed","errors":[{"message":"expected length <= 100","location":"body.description", ...}]
```
`server.json`'s `description` is **553 chars**, so `registry-backfill.yml` (and `publish.yml` on release) can't publish the server to the MCP registry. Surfaced by the run of the new backfill workflow just added in 60cb1dd6 (#20).

## Fix

Shorten `description` to a **98-char** summary that keeps the core value: `Real-time oil, gas & commodity prices via MCP: 26 tools, 70+ commodities, natural-language queries`. One-line change; JSON validated. `package.json`'s longer description is unaffected (npm has no 100-char cap).

## After merge
Re-run **MCP registry backfill** (workflow_dispatch) to confirm the publish now returns 200 (was 422).

Note: "Live API tests" failing is separate/pre-existing (fails on prior commits too) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
