### PR TITLE
chore: glama.json maintainership (#19)

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["karlwaldman"]
+}


### PR DESCRIPTION
Asserts maintainership for the Glama listing (glama.ai/mcp/servers/OilpriceAPI/oil-price-api, currently unclaimed, showing 21 tools @ v2.0.0). Part of the #19 listings refresh. Live-smoke check fails for the pre-existing prod data issue (oilpriceapi-api#3889) — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)