### PR TITLE
feat: well-production MCP tool + fix stale drilling formatter (#31), 402 boundary note (#10)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Keep npm deps and GitHub Actions current. Weekly batches to keep PR noise
+# low; dev-dep vulnerabilities (vite/vitest chain) get picked up here instead
+# of waiting for a manual `npm audit`.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Backed by [OilPriceAPI](https://oilpriceapi.com) — the commodity price API beh
 
 ## Features
 
-- **26 Tools** — 17 read tools (spot prices, history, futures, marine fuels, rig counts, diesel by state, storage, OPEC production, forecasts, EIA oil inventories, well permits, refining spreads) plus 4 authenticated price-alert tools (create/list/delete persistent alerts + trigger activity) and 5 agent tools (multi-commodity market briefs, persistent price watches)
+- **27 Tools** — 18 read tools (spot prices, history, futures, marine fuels, rig counts, diesel by state, storage, OPEC production, forecasts, EIA oil inventories, well permits, well production, refining spreads) plus 4 authenticated price-alert tools (create/list/delete persistent alerts + trigger activity) and 5 agent tools (multi-commodity market briefs, persistent price watches)
 - **5 Resources** — subscribable price snapshots for Brent, WTI, Natural Gas, Diesel, and all commodities
 - **6 Prompts** — pre-built analyst templates (daily briefing, spread analysis, gas markets, commodity report, diesel costs, supply analysis)
 - **Natural language** — ask for "brent oil" or "natural gas", not codes
@@ -156,25 +156,26 @@ npm install -g oilpriceapi-mcp
 
 All tools are prefixed with `opa_` to avoid name collisions when multiple MCP servers are loaded.
 
-| Tool                      | Description                                                       |
-| ------------------------- | ----------------------------------------------------------------- |
-| `opa_get_price`           | Current spot price for a single commodity                         |
-| `opa_market_overview`     | All commodity prices in one call, grouped by category             |
-| `opa_compare_prices`      | Side-by-side comparison of 2-5 commodities with spread            |
-| `opa_list_commodities`    | Full commodity catalog (fetched live from API)                    |
-| `opa_get_history`         | Historical prices with high/low/avg/change (day/week/month/year)  |
-| `opa_get_futures`         | Front-month futures (Brent BZ, WTI CL, ICE Gasoil, TTF, JKM, EUA) |
-| `opa_get_futures_curve`   | Full forward curve with contango/backwardation analysis           |
-| `opa_get_marine_fuels`    | Bunker fuel prices by port and fuel type (VLSFO/MGO/IFO380)       |
-| `opa_get_rig_counts`      | Baker Hughes US rig count with week-over-week change              |
-| `opa_get_drilling`        | Drilling intelligence: wells, permits, completions by region      |
-| `opa_get_diesel_by_state` | AAA retail diesel price for any US state (50 states + DC)         |
-| `opa_get_storage`         | Cushing and SPR oil storage/inventory levels                      |
-| `opa_get_opec_production` | OPEC country-level production data                                |
-| `opa_get_forecasts`       | EIA STEO energy price forecasts                                   |
-| `opa_get_oil_inventories` | EIA weekly petroleum stocks (latest/summary/by_product)           |
-| `opa_get_well_permits`    | US well drilling permits (latest/by_state/by_operator)            |
-| `opa_get_spread`          | Refining/trading spreads (crack, basis, margin)                   |
+| Tool                      | Description                                                                                     |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| `opa_get_price`           | Current spot price for a single commodity                                                       |
+| `opa_market_overview`     | All commodity prices in one call, grouped by category                                           |
+| `opa_compare_prices`      | Side-by-side comparison of 2-5 commodities with spread                                          |
+| `opa_list_commodities`    | Full commodity catalog (fetched live from API)                                                  |
+| `opa_get_history`         | Historical prices with high/low/avg/change (day/week/month/year)                                |
+| `opa_get_futures`         | Front-month futures (Brent BZ, WTI CL, ICE Gasoil, TTF, JKM, EUA)                               |
+| `opa_get_futures_curve`   | Full forward curve with contango/backwardation analysis                                         |
+| `opa_get_marine_fuels`    | Bunker fuel prices by port and fuel type (VLSFO/MGO/IFO380)                                     |
+| `opa_get_rig_counts`      | Baker Hughes US rig count with week-over-week change                                            |
+| `opa_get_drilling`        | Drilling snapshot: rig counts, frac spreads, 30-day permits, DUCs                               |
+| `opa_get_diesel_by_state` | AAA retail diesel price for any US state (50 states + DC)                                       |
+| `opa_get_storage`         | Cushing and SPR oil storage/inventory levels                                                    |
+| `opa_get_opec_production` | OPEC country-level production data                                                              |
+| `opa_get_forecasts`       | EIA STEO energy price forecasts                                                                 |
+| `opa_get_oil_inventories` | EIA weekly petroleum stocks (latest/summary/by_product)                                         |
+| `opa_get_well_permits`    | US well drilling permits (latest/by_state/by_operator)                                          |
+| `opa_get_well_production` | US well production — beta coverage (summary/states/state/well/top_producers/cycle_time/cohorts) |
+| `opa_get_spread`          | Refining/trading spreads (crack, basis, margin)                                                 |
 
 ### Price Alert Tools (authenticated)
 
@@ -299,6 +300,15 @@ This MCP server runs locally on your machine and only communicates with the OilP
 - **Demo mode**: without an API key, price tools call the keyless demo endpoint on the same host; no key or account data is involved.
 
 Questions: [support@oilpriceapi.com](mailto:support@oilpriceapi.com)
+
+## Pricing Boundary (HTTP 402)
+
+Where the free/paid line sits for this server (#10):
+
+- **Always open**: the MCP server itself (MIT), setup, docs, discovery (tool listing), and keyless demo mode for low-volume evaluation.
+- **Free API key**: live prices for 40+ commodities within the free tier's request limits.
+- **Behind the paywall**: high-volume usage and premium datasets (futures, energy intelligence, well permits/production, alerts at scale). When a request crosses that boundary the API returns a standard **HTTP 402/403/429 with the exact limit or feature gate in the body**, and this server surfaces that message plus an upgrade link — agents get a machine-readable stop, never a silent failure.
+- **x402 protocol**: per-request crypto micropayments via the [x402 protocol](https://www.x402.org/) are **not currently supported** — payment is by account plan (Stripe), authenticated with your API key.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,46 +25,43 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -121,14 +118,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -140,9 +137,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -150,9 +147,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -167,9 +164,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -184,9 +181,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -201,9 +198,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -218,9 +215,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -235,13 +232,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -252,13 +252,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -269,13 +272,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -286,13 +292,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -303,13 +312,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -320,13 +332,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -337,9 +352,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -354,9 +369,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -364,16 +379,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -388,9 +405,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -405,9 +422,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -419,9 +436,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -874,9 +891,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -985,12 +1002,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1009,9 +1026,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -1167,9 +1184,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1179,9 +1196,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1230,9 +1247,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1613,9 +1630,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1736,9 +1753,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1758,9 +1775,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -1778,7 +1795,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1800,12 +1817,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1848,14 +1866,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1864,21 +1882,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/router": {
@@ -1976,14 +1994,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1995,13 +2013,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2105,14 +2123,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2202,17 +2220,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2228,8 +2246,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/scripts/live-smoke.mjs
+++ b/scripts/live-smoke.mjs
@@ -109,13 +109,40 @@ function rateLimitGuard(status, label) {
   }
 }
 
+// Sentinel thrown when a plan-gated endpoint answers 402/403 because the CI
+// key lacks the entitlement (e.g. energy intelligence for well production /
+// drilling). That is the documented paywall behavior — the MCP tools surface
+// it with an upgrade link — NOT a contract regression, so callers SKIP.
+class PlanGated extends Error {
+  constructor(label, status) {
+    super(`plan-gated (HTTP ${status}): ${label}`);
+    this.name = "PlanGated";
+  }
+}
+
+// Throw PlanGated when a premium endpoint answers 402/403 so the per-check
+// try/catch can SKIP instead of failing. Only use on endpoints where the
+// shared CI key may legitimately lack the entitlement.
+function planGateGuard(status, label) {
+  if (status === 402 || status === 403) {
+    throw new PlanGated(label, status);
+  }
+}
+
 // Centralised per-check error handling. Returns the new failure count: a 429
-// (RateLimited) is logged as a tolerated SKIP and does NOT increment failures;
-// any other error is a real failure and increments.
+// (RateLimited) or an entitlement 402/403 (PlanGated) is logged as a
+// tolerated SKIP and does NOT increment failures; any other error is a real
+// failure and increments.
 function handleCheckError(err, failures) {
   if (err instanceof RateLimited) {
     console.log(
       `SKIP (rate-limited (shared CI key), skipping live assertion): ${err.message}`,
+    );
+    return failures;
+  }
+  if (err instanceof PlanGated) {
+    console.log(
+      `SKIP (plan-gated, CI key lacks the entitlement — tolerated): ${err.message}`,
     );
     return failures;
   }
@@ -278,9 +305,14 @@ async function main() {
   // 5. Well production summary — GET /v1/well-production (#31)
   // What opa_get_well_production (summary view) builds. Require 200 + a
   // non-empty top_states array with numeric production figures.
+  // TOLERANT of 402/403: well production is a plan-gated dataset and the
+  // shared CI key may not carry the energy-intelligence entitlement. A gate
+  // response is the documented paywall behavior (the MCP tool surfaces it
+  // with an upgrade link), NOT a contract regression — SKIP, don't fail.
   try {
     const { status, body } = await getJson("/v1/well-production");
     rateLimitGuard(status, "GET /v1/well-production");
+    planGateGuard(status, "GET /v1/well-production");
     assert(status === 200, `well-production expected 200, got ${status}`);
     const data = body && body.data;
     assert(
@@ -299,7 +331,7 @@ async function main() {
     );
   } catch (err) {
     failures = handleCheckError(err, failures);
-    if (!(err instanceof RateLimited)) {
+    if (!(err instanceof RateLimited) && !(err instanceof PlanGated)) {
       console.error(`FAIL (well-production): ${err.message}`);
     }
   }
@@ -311,9 +343,11 @@ async function main() {
   // well_permits: {...}, duc_wells_total, ... } — the old
   // total_wells/active_rigs shape is gone, and the pre-#31 formatter crashed
   // on it. This check pins the new contract.
+  // Also TOLERANT of 402/403 — drilling is plan-gated like well production.
   try {
     const { status, body } = await getJson("/v1/drilling/latest");
     rateLimitGuard(status, "GET /v1/drilling/latest");
+    planGateGuard(status, "GET /v1/drilling/latest");
     assert(status === 200, `drilling expected 200, got ${status}`);
     const data = body && body.data;
     assert(
@@ -325,7 +359,7 @@ async function main() {
     );
   } catch (err) {
     failures = handleCheckError(err, failures);
-    if (!(err instanceof RateLimited)) {
+    if (!(err instanceof RateLimited) && !(err instanceof PlanGated)) {
       console.error(`FAIL (drilling): ${err.message}`);
     }
   }

--- a/scripts/live-smoke.mjs
+++ b/scripts/live-smoke.mjs
@@ -273,7 +273,64 @@ async function main() {
     }
   }
 
-  // 5. WRITE round-trip (opt-in) — create -> poll events -> delete.
+  await sleep(RATE_LIMIT_MS);
+
+  // 5. Well production summary — GET /v1/well-production (#31)
+  // What opa_get_well_production (summary view) builds. Require 200 + a
+  // non-empty top_states array with numeric production figures.
+  try {
+    const { status, body } = await getJson("/v1/well-production");
+    rateLimitGuard(status, "GET /v1/well-production");
+    assert(status === 200, `well-production expected 200, got ${status}`);
+    const data = body && body.data;
+    assert(
+      data && Array.isArray(data.top_states) && data.top_states.length > 0,
+      `well-production missing data.top_states[]: ${JSON.stringify(body).slice(0, 300)}`,
+    );
+    const top = data.top_states[0];
+    assert(
+      typeof top.state === "string" &&
+        typeof top.oil_bbl === "number" &&
+        Number.isFinite(top.oil_bbl),
+      "well-production top state missing state/oil_bbl",
+    );
+    console.log(
+      `PASS: GET /v1/well-production -> 200, top state ${top.state} @ ${top.oil_bbl} bbl (${top.period})`,
+    );
+  } catch (err) {
+    failures = handleCheckError(err, failures);
+    if (!(err instanceof RateLimited)) {
+      console.error(`FAIL (well-production): ${err.message}`);
+    }
+  }
+
+  await sleep(RATE_LIMIT_MS);
+
+  // 6. Drilling snapshot — GET /v1/drilling/latest (#31)
+  // The endpoint's CURRENT shape is { rig_counts: {...}, frac_spread_count,
+  // well_permits: {...}, duc_wells_total, ... } — the old
+  // total_wells/active_rigs shape is gone, and the pre-#31 formatter crashed
+  // on it. This check pins the new contract.
+  try {
+    const { status, body } = await getJson("/v1/drilling/latest");
+    rateLimitGuard(status, "GET /v1/drilling/latest");
+    assert(status === 200, `drilling expected 200, got ${status}`);
+    const data = body && body.data;
+    assert(
+      data && data.rig_counts && typeof data.rig_counts === "object",
+      `drilling missing data.rig_counts: ${JSON.stringify(body).slice(0, 300)}`,
+    );
+    console.log(
+      `PASS: GET /v1/drilling/latest -> 200, rig_counts keys: ${Object.keys(data.rig_counts).join(", ")}`,
+    );
+  } catch (err) {
+    failures = handleCheckError(err, failures);
+    if (!(err instanceof RateLimited)) {
+      console.error(`FAIL (drilling): ${err.message}`);
+    }
+  }
+
+  // 7. WRITE round-trip (opt-in) — create -> poll events -> delete.
   // Guarded behind SMOKE_WRITE_SUBSCRIPTIONS=1 so the default run never writes
   // to prod. When enabled, the created watch is ALWAYS deleted in the same run
   // (even if a mid-step assertion fails) so prod is not littered.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,6 +21,11 @@ import {
   SIGNUP_URL,
   UPGRADE_URL,
   createSandboxServer,
+  wellProductionEndpoint,
+  formatWellProduction,
+  formatDrillingData,
+  WELL_PRODUCTION_VIEWS,
+  WELL_PRODUCTION_BETA_NOTE,
 } from "../index.js";
 
 // ---------------------------------------------------------------------------
@@ -1013,8 +1018,8 @@ describe("tool registration metadata", () => {
   const DELETE_TOOLS = ["opa_delete_price_alert", "opa_delete_subscription"];
   const WRITE_TOOLS = new Set([...CREATE_TOOLS, ...DELETE_TOOLS]);
 
-  it("registers exactly 26 tools", () => {
-    expect(Object.keys(tools)).toHaveLength(26);
+  it("registers exactly 27 tools", () => {
+    expect(Object.keys(tools)).toHaveLength(27);
   });
 
   it("registers all four write tools (creates + deletes)", () => {
@@ -1083,5 +1088,427 @@ describe("tool registration metadata", () => {
         openWorldHint: true,
       });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #31 — well production tool (opa_get_well_production)
+// ---------------------------------------------------------------------------
+
+describe("wellProductionEndpoint (#31) - request mapping", () => {
+  it("maps every view to its /v1/well-production* endpoint", () => {
+    expect(wellProductionEndpoint("summary")).toEqual({
+      endpoint: "/v1/well-production",
+    });
+    expect(wellProductionEndpoint("states")).toEqual({
+      endpoint: "/v1/well-production/states",
+    });
+    expect(wellProductionEndpoint("state", { state: "TX" })).toEqual({
+      endpoint: "/v1/well-production/states/TX",
+    });
+    expect(
+      wellProductionEndpoint("well", { api_number: "42329447130000" }),
+    ).toEqual({
+      endpoint: "/v1/well-production/wells/42329447130000",
+    });
+    expect(wellProductionEndpoint("top_producers")).toEqual({
+      endpoint: "/v1/well-production/top-producers",
+    });
+    expect(wellProductionEndpoint("cycle_time")).toEqual({
+      endpoint: "/v1/well-production/cycle-time",
+    });
+    expect(wellProductionEndpoint("cohorts")).toEqual({
+      endpoint: "/v1/well-production/cycle-time/cohorts",
+    });
+  });
+
+  it("resolves full state names and applies the state filter to top_producers / cycle_time", () => {
+    expect(wellProductionEndpoint("state", { state: "new mexico" })).toEqual({
+      endpoint: "/v1/well-production/states/NM",
+    });
+    expect(wellProductionEndpoint("top_producers", { state: "Texas" })).toEqual(
+      { endpoint: "/v1/well-production/top-producers?state=TX" },
+    );
+    expect(wellProductionEndpoint("cycle_time", { state: "TX" })).toEqual({
+      endpoint: "/v1/well-production/cycle-time?state=TX",
+    });
+  });
+
+  it("rejects an unsupported state", () => {
+    const result = wellProductionEndpoint("state", { state: "Atlantis" });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("Atlantis");
+    expect((result as { error: string }).error).toContain(
+      "not a recognized US state",
+    );
+  });
+
+  it("requires a state for the state view", () => {
+    const result = wellProductionEndpoint("state");
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("requires a state");
+  });
+
+  it("rejects an invalid API well number (must be 14 digits)", () => {
+    for (const bad of ["1234", "", "not-a-number", "4232944713000"]) {
+      const result = wellProductionEndpoint("well", { api_number: bad });
+      expect(result, `api_number '${bad}'`).toHaveProperty("error");
+      expect((result as { error: string }).error).toContain("14-digit");
+    }
+  });
+
+  it("normalizes dashed API numbers to digits", () => {
+    expect(
+      wellProductionEndpoint("well", { api_number: "42-329-44713-00-00" }),
+    ).toEqual({ endpoint: "/v1/well-production/wells/42329447130000" });
+  });
+});
+
+describe("formatWellProduction (#31) - formatting", () => {
+  it("formats the summary view with top states and flags an unreported national period", () => {
+    const text = formatWellProduction("summary", {
+      national: {
+        period: "2026-07",
+        oil_bbl: 0,
+        gas_mcf: 0,
+        water_bbl: 0,
+        boe: 0,
+        days_producing: null,
+        source: "market_reporting",
+      },
+      top_states: [
+        {
+          state: "TX",
+          period: "2026-04",
+          oil_bbl: 174743000,
+          oil_bpd: 5824767,
+          gas_mcf: 1164406000,
+          boe: 368810667,
+        },
+      ],
+    });
+
+    expect(text).toContain("US Well Production (summary)");
+    expect(text).toContain("Not yet reported for 2026-07");
+    expect(text).toContain("**TX** (2026-04)");
+    expect(text).toContain("174,743,000");
+    expect(text.length).toBeGreaterThan(0);
+  });
+
+  it("formats a state monthly history", () => {
+    const text = formatWellProduction("state", {
+      state: "TX",
+      period: { start: "2024-07-13", end: "2026-07-13" },
+      count: 1,
+      data: [
+        {
+          period: "2025-06",
+          oil_bbl: 172690000,
+          gas_mcf: 1110000000,
+          water_bbl: null,
+          boe: 357690000,
+          days_producing: null,
+          source: "eia_api",
+        },
+      ],
+    });
+
+    expect(text).toContain("**State**: TX");
+    expect(text).toContain("2024-07-13 → 2026-07-13");
+    expect(text).toContain("**2025-06**");
+    expect(text).toContain("[eia_api]");
+  });
+
+  it("formats a single-well history with well metadata", () => {
+    const text = formatWellProduction("well", {
+      api_number: "50029237980000",
+      operator: "Hilcorp Alaska, LLC",
+      well_name: "MILNE PT UNIT J-40",
+      state: "AK",
+      count: 1,
+      data: [
+        {
+          period: "2024-11",
+          oil_bbl: 27336,
+          gas_mcf: 9231,
+          water_bbl: 42395,
+          boe: 28875,
+          days_producing: 30,
+          source: "ak_aogcc",
+        },
+      ],
+    });
+
+    expect(text).toContain("MILNE PT UNIT J-40");
+    expect(text).toContain("Hilcorp Alaska, LLC");
+    expect(text).toContain("50029237980000");
+    expect(text).toContain("27,336");
+    expect(text).toContain("30 days");
+  });
+
+  it("formats top producers", () => {
+    const text = formatWellProduction("top_producers", {
+      state: "TX",
+      period: { start: "2025-07-01", end: "2026-07-13" },
+      count: 1,
+      producers: [
+        {
+          api_number: "42329447130000",
+          operator: "FIREBIRD ENERGY II LLC",
+          well_name: "MBE",
+          total_oil_bbl: 1004658,
+          total_gas_mcf: 1605878,
+          months_producing: 7,
+        },
+      ],
+    });
+
+    expect(text).toContain("FIREBIRD ENERGY II LLC");
+    expect(text).toContain("1,004,658");
+    expect(text).toContain("7 months");
+  });
+
+  it("renders cycle_time / cohorts stats as JSON", () => {
+    const text = formatWellProduction("cycle_time", {
+      well_count: 10000,
+      cycle_time_stats: { median_days: 400 },
+    });
+    expect(text).toContain('"median_days": 400');
+  });
+
+  it("ALWAYS appends the beta coverage caveat — never claims complete US well-level production", () => {
+    for (const view of WELL_PRODUCTION_VIEWS) {
+      const text = formatWellProduction(view, {});
+      expect(text, view).toContain(WELL_PRODUCTION_BETA_NOTE);
+      expect(text, view).toContain("NOT complete US well-level production");
+    }
+  });
+});
+
+describe("opa_get_well_production (#31) - negative paths via tool handler", () => {
+  const server = createSandboxServer();
+  const tools = (
+    server as unknown as {
+      _registeredTools: Record<
+        string,
+        {
+          handler: (
+            args: Record<string, unknown>,
+            extra: Record<string, unknown>,
+          ) => Promise<{
+            content: Array<{ type: string; text: string }>;
+            isError?: boolean;
+          }>;
+        }
+      >;
+    }
+  )._registeredTools;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the keyless teaser when no API key is configured", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "");
+    vi.stubEnv("OIL_PRICE_API_KEY", "");
+
+    const result = await tools.opa_get_well_production.handler(
+      { view: "summary" },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("opa_get_well_production");
+    expect(result.content[0].text).toContain(SIGNUP_URL);
+    expect(result.content[0].text).not.toContain("Authentication failed");
+  });
+
+  it("surfaces the 402 entitlement gate with the upgrade link", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 402,
+        statusText: "Payment Required",
+        headers: { get: () => null },
+        text: async () =>
+          JSON.stringify({
+            message: "Well production requires the Pro plan",
+          }),
+      }),
+    );
+
+    // Calling the handler directly bypasses the SDK's error-to-result
+    // conversion, so the ApiGateError surfaces as a rejection here.
+    await expect(
+      tools.opa_get_well_production.handler({ view: "summary" }, {}),
+    ).rejects.toMatchObject({
+      name: "ApiGateError",
+      status: 402,
+      message: expect.stringContaining(UPGRADE_URL),
+    });
+  });
+
+  it("returns a coverage-aware error when a state has no data (API 404)", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        headers: { get: () => null },
+        text: async () =>
+          JSON.stringify({
+            error: {
+              code: "DATA_NOT_AVAILABLE",
+              message: "No production data for state: HI",
+            },
+          }),
+      }),
+    );
+
+    const result = await tools.opa_get_well_production.handler(
+      { view: "state", state: "HI" },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("HI");
+    expect(result.content[0].text).toContain("Beta coverage");
+  });
+
+  it("rejects an invalid API number without calling the API", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await tools.opa_get_well_production.handler(
+      { view: "well", api_number: "1234" },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("14-digit");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns a generic error result on API failure (non-gate)", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        headers: { get: () => null },
+        text: async () => "",
+      }),
+    );
+
+    const result = await tools.opa_get_well_production.handler(
+      { view: "cohorts" },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "Well production data not available",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #31 — opa_get_drilling formatter matches the CURRENT /v1/drilling/latest
+// shape (the old total_wells/active_rigs shape is no longer served and made
+// every keyed call crash).
+// ---------------------------------------------------------------------------
+
+describe("formatDrillingData (#31) - current live shape", () => {
+  const LIVE_SHAPE = {
+    rig_counts: {
+      US_RIG_COUNT: 581,
+      CANADA_RIG_COUNT: 179,
+      INTERNATIONAL_RIG_COUNT: 1073,
+    },
+    frac_spread_count: 200,
+    well_permits: {
+      last_30d: 16423,
+      by_state: { UT: 15403, TX: 679 },
+    },
+    duc_wells_total: 2465,
+    deltas: { rig_counts: -3, well_permits: 15217 },
+    last_updated: "2026-07-13T00:05:27.388Z",
+  };
+
+  it("formats the current payload without throwing", () => {
+    const text = formatDrillingData(LIVE_SHAPE);
+
+    expect(text).toContain("Drilling Activity Snapshot");
+    expect(text).toContain("581");
+    expect(text).toContain("Frac Spread Count**: 200");
+    expect(text).toContain("16,423");
+    expect(text).toContain("**UT**: 15,403");
+    expect(text).toContain("DUC Wells");
+    expect(text).toContain("2,465");
+    expect(text).toContain("-3");
+    expect(text).toContain("2026-07-13");
+  });
+
+  it("tolerates missing optional sections", () => {
+    const text = formatDrillingData({});
+    expect(text).toContain("Drilling Activity Snapshot");
+    expect(text).toContain("oilpriceapi.com");
+  });
+
+  it("keyed drilling call formats the live shape end-to-end", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ status: "success", data: LIVE_SHAPE }),
+      }),
+    );
+
+    const server = createSandboxServer();
+    const tools = (
+      server as unknown as {
+        _registeredTools: Record<
+          string,
+          {
+            handler: (
+              args: Record<string, unknown>,
+              extra: Record<string, unknown>,
+            ) => Promise<{
+              content: Array<{ type: string; text: string }>;
+              isError?: boolean;
+            }>;
+          }
+        >;
+      }
+    )._registeredTools;
+
+    const result = await tools.opa_get_drilling.handler({}, {});
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Rig Counts");
+    expect(result.content[0].text).toContain("Permits by State");
+
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("keylessTeaserResult covers opa_get_well_production (#31)", () => {
+  it("returns the well-production teaser with the beta caveat wording", () => {
+    const text = keylessTeaserResult("opa_get_well_production").content[0].text;
+    expect(text).toContain("opa_get_well_production");
+    expect(text).toContain("beta coverage");
+    expect(text).toContain(SIGNUP_URL);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,11 @@
  * limit/feature gate hit by the API plus an upgrade link (see ApiGateError in
  * makeApiRequest and alertHttpError for the authenticated tools).
  *
- * 26 tools total (opa_ prefixed):
+ * 27 tools total (opa_ prefixed):
  *
- * 17 read-only tools: prices, history, futures, marine fuels, rig counts,
+ * 18 read-only tools: prices, history, futures, marine fuels, rig counts,
  * drilling, diesel-by-state, storage, OPEC production, forecasts, EIA oil
- * inventories, well permits, refining spreads.
+ * inventories, well permits, well production, refining spreads.
  *
  * 4 authenticated price-alert tools (opa_*_price_alert / opa_get_alert_triggers):
  * create/list/delete persistent price alerts tied to the user's account and read
@@ -445,13 +445,19 @@ interface RigCountData {
   source?: string;
 }
 
+// Shape of GET /v1/drilling/latest as served by the current API (verified
+// live 2026-07-13). The pre-#31 shape (total_wells/active_rigs/
+// region_breakdown/date) is no longer what the endpoint returns.
 interface DrillingData {
-  total_wells: number;
-  active_rigs: number;
-  permits_issued?: number;
-  completions?: number;
-  region_breakdown?: Array<{ region: string; count: number }>;
-  date: string;
+  rig_counts?: Record<string, number>;
+  frac_spread_count?: number;
+  well_permits?: {
+    last_30d?: number;
+    by_state?: Record<string, number>;
+  };
+  duc_wells_total?: number;
+  deltas?: Record<string, number>;
+  last_updated?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -1282,9 +1288,9 @@ const KEYLESS_TOOL_TEASERS: Record<string, { does: string; example: string }> =
       example: "Oil Rigs: NNN · Gas Rigs: NNN · Total: NNN (±N vs prior week)",
     },
     opa_get_drilling: {
-      does: "Returns drilling intelligence: active wells, rigs, permits, and completions with a regional breakdown.",
+      does: "Returns a drilling activity snapshot: US/Canada/international rig counts, frac spread count, well permits (last 30 days, by state), and DUC well totals.",
       example:
-        "Total Wells: N,NNN · Active Rigs: NNN · Permits Issued: NNN · Completions: NNN",
+        "US Rigs: NNN · Frac Spreads: NNN · Permits (30d): N,NNN · DUC Wells: N,NNN",
     },
     opa_get_diesel_by_state: {
       does: "Returns the AAA average retail diesel price for any US state.",
@@ -1314,6 +1320,11 @@ const KEYLESS_TOOL_TEASERS: Record<string, { does: string; example: string }> =
       does: "Returns US oil & gas well drilling permit data, filterable by state or operator.",
       example:
         "TX: NNN permits · NM: NNN permits · ... (latest week, by state/operator)",
+    },
+    opa_get_well_production: {
+      does: "Returns US oil & gas well production data (beta coverage): national/state monthly summaries, per-state history, per-well history by API number, top producers, and drill-to-production cycle times.",
+      example:
+        "TX (YYYY-MM): NNN,NNN,NNN bbl oil · N,NNN,NNN,NNN mcf gas · NNN,NNN,NNN boe",
     },
     opa_get_spread: {
       does: "Returns refining and trading spreads: crack spreads, basis differentials, and blending/transport margins.",
@@ -1389,8 +1400,8 @@ export function keylessTeaserResult(toolName: string) {
 }
 
 // =========================================================================
-// READ TOOLS (17 — opa_ prefixed to avoid collisions). Plus 4 authenticated
-// price-alert tools further below, for 21 tools total.
+// READ TOOLS (18 — opa_ prefixed to avoid collisions). Plus 4 authenticated
+// price-alert tools further below, for 22 tools total.
 // =========================================================================
 
 server.registerTool(
@@ -2014,12 +2025,68 @@ server.registerTool(
   },
 );
 
+/**
+ * Format the CURRENT live /v1/drilling/latest payload (#31). The old
+ * formatter assumed a total_wells/active_rigs/region_breakdown shape the API
+ * no longer serves, so every keyed call crashed on
+ * `data.total_wells.toLocaleString()`. Exported for tests.
+ */
+export function formatDrillingData(data: DrillingData): string {
+  let text = `# Drilling Activity Snapshot\n\n`;
+
+  if (data.rig_counts && Object.keys(data.rig_counts).length > 0) {
+    text += `## Rig Counts\n`;
+    for (const [key, value] of Object.entries(data.rig_counts)) {
+      const label = key
+        .replace(/_/g, " ")
+        .toLowerCase()
+        .replace(/\b\w/g, (c) => c.toUpperCase())
+        .replace(/^Us /, "US ");
+      text += `- **${label}**: ${value.toLocaleString()}\n`;
+    }
+    text += `\n`;
+  }
+
+  if (data.frac_spread_count !== undefined) {
+    text += `- **Frac Spread Count**: ${data.frac_spread_count.toLocaleString()}\n`;
+  }
+  if (data.duc_wells_total !== undefined) {
+    text += `- **DUC Wells (drilled, uncompleted)**: ${data.duc_wells_total.toLocaleString()}\n`;
+  }
+
+  const permits = data.well_permits;
+  if (permits?.last_30d !== undefined) {
+    text += `- **Well Permits (last 30 days)**: ${permits.last_30d.toLocaleString()}\n`;
+  }
+  if (permits?.by_state && Object.keys(permits.by_state).length > 0) {
+    text += `\n## Permits by State (last 30 days)\n`;
+    for (const [state, count] of Object.entries(permits.by_state)) {
+      text += `- **${state}**: ${count.toLocaleString()}\n`;
+    }
+  }
+
+  if (data.deltas && Object.keys(data.deltas).length > 0) {
+    text += `\n## Week-over-Week Changes\n`;
+    for (const [key, value] of Object.entries(data.deltas)) {
+      const sign = value >= 0 ? "+" : "";
+      text += `- **${key.replace(/_/g, " ")}**: ${sign}${value.toLocaleString()}\n`;
+    }
+  }
+
+  if (data.last_updated) {
+    text += `\n- **Last Updated**: ${data.last_updated}\n`;
+  }
+
+  text += `\n_Data from [OilPriceAPI](https://oilpriceapi.com)_`;
+  return text;
+}
+
 server.registerTool(
   "opa_get_drilling",
   {
     title: "Get Drilling Activity",
     description:
-      "Get drilling intelligence data including active wells, permits issued, and completions by region. Use when the user asks about drilling activity, well permits, or upstream operations. Returns totals and regional breakdown.",
+      "Get a drilling activity snapshot: US, Canada, and international rig counts, frac spread count, well permits issued in the last 30 days (with a by-state breakdown), and DUC (drilled-uncompleted) well totals. Use when the user asks about drilling activity, rigs vs frac spreads, or upstream operations. Requires a paid plan with energy intelligence access.",
     inputSchema: {},
     annotations: READ_TOOL_ANNOTATIONS,
   },
@@ -2032,30 +2099,11 @@ server.registerTool(
 
     if (!response || response.status !== "success") {
       return errorResult(
-        "Drilling intelligence data not available. This requires a paid plan with energy intelligence access.",
+        "Drilling activity data not available. This requires a paid plan with energy intelligence access.",
       );
     }
 
-    const data = response.data;
-    let text = `# Drilling Intelligence\n\n`;
-    text += `- **Total Wells**: ${data.total_wells.toLocaleString()}\n`;
-    text += `- **Active Rigs**: ${data.active_rigs.toLocaleString()}\n`;
-    if (data.permits_issued !== undefined)
-      text += `- **Permits Issued**: ${data.permits_issued.toLocaleString()}\n`;
-    if (data.completions !== undefined)
-      text += `- **Completions**: ${data.completions.toLocaleString()}\n`;
-    text += `- **Date**: ${data.date}\n`;
-
-    if (data.region_breakdown?.length) {
-      text += `\n## By Region\n`;
-      for (const r of data.region_breakdown) {
-        text += `- **${r.region}**: ${r.count}\n`;
-      }
-    }
-
-    text += `\n_Data from [OilPriceAPI](https://oilpriceapi.com)_`;
-
-    return textResult(text);
+    return textResult(formatDrillingData(response.data));
   },
 );
 
@@ -2343,6 +2391,290 @@ server.registerTool(
     text += "\n_Data from [OilPriceAPI](https://oilpriceapi.com)_";
 
     return textResult(text);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Well production (#31) — /v1/well-production*
+//
+// BETA COVERAGE: monthly state-level production (EIA + selected state
+// regulators) plus well-level histories for selected states only. This is
+// NOT complete US well-level production — descriptions and output say so.
+// ---------------------------------------------------------------------------
+
+export const WELL_PRODUCTION_VIEWS = [
+  "summary",
+  "states",
+  "state",
+  "well",
+  "top_producers",
+  "cycle_time",
+  "cohorts",
+] as const;
+
+export type WellProductionView = (typeof WELL_PRODUCTION_VIEWS)[number];
+
+export const WELL_PRODUCTION_BETA_NOTE =
+  "_Beta coverage: monthly state-level production (EIA + selected state regulators) and well-level histories for selected states only — NOT complete US well-level production. Data from [OilPriceAPI](https://oilpriceapi.com)_";
+
+interface WellProductionMonth {
+  period?: string;
+  oil_bbl?: number | null;
+  oil_bpd?: number | null;
+  gas_mcf?: number | null;
+  water_bbl?: number | null;
+  boe?: number | null;
+  days_producing?: number | null;
+  source?: string;
+  state?: string;
+}
+
+interface WellProductionSummaryData {
+  national?: WellProductionMonth;
+  top_states?: WellProductionMonth[];
+}
+
+interface WellProductionStatesData {
+  period?: string;
+  count?: number;
+  states?: WellProductionMonth[];
+}
+
+interface WellProductionSeriesData {
+  state?: string;
+  api_number?: string;
+  operator?: string;
+  well_name?: string;
+  period?: { start?: string; end?: string };
+  count?: number;
+  data?: WellProductionMonth[];
+}
+
+interface WellProductionTopProducersData {
+  state?: string;
+  period?: { start?: string; end?: string };
+  count?: number;
+  producers?: Array<{
+    api_number?: string;
+    operator?: string;
+    well_name?: string;
+    total_oil_bbl?: number;
+    total_gas_mcf?: number;
+    months_producing?: number;
+  }>;
+}
+
+/**
+ * Map a well-production view + options to the API endpoint (#31).
+ * Returns { endpoint } or { error } with an actionable message.
+ * Exported for tests.
+ */
+export function wellProductionEndpoint(
+  view: WellProductionView,
+  opts: { state?: string; api_number?: string } = {},
+): { endpoint: string } | { error: string } {
+  const resolveState = (): { code: string } | { error: string } => {
+    const code = resolveStateCode(opts.state!);
+    if (!code) {
+      return {
+        error: `'${opts.state}' is not a recognized US state. Use a full state name (e.g., 'Texas') or 2-letter code (e.g., 'TX').`,
+      };
+    }
+    return { code };
+  };
+
+  switch (view) {
+    case "summary":
+      return { endpoint: "/v1/well-production" };
+    case "states":
+      return { endpoint: "/v1/well-production/states" };
+    case "state": {
+      if (!opts.state) {
+        return {
+          error:
+            "The 'state' view requires a state parameter (e.g., state: 'TX').",
+        };
+      }
+      const resolved = resolveState();
+      if ("error" in resolved) return resolved;
+      return { endpoint: `/v1/well-production/states/${resolved.code}` };
+    }
+    case "well": {
+      const api = (opts.api_number ?? "").replace(/[^0-9]/g, "");
+      if (api.length !== 14) {
+        return {
+          error:
+            "The 'well' view requires a 14-digit API well number (api_number), e.g. '42329447130000'. Use the top_producers or cycle_time views to discover API numbers.",
+        };
+      }
+      return { endpoint: `/v1/well-production/wells/${api}` };
+    }
+    case "top_producers":
+    case "cycle_time": {
+      const base =
+        view === "top_producers"
+          ? "/v1/well-production/top-producers"
+          : "/v1/well-production/cycle-time";
+      if (opts.state) {
+        const resolved = resolveState();
+        if ("error" in resolved) return resolved;
+        return { endpoint: `${base}?state=${resolved.code}` };
+      }
+      return { endpoint: base };
+    }
+    case "cohorts":
+      return { endpoint: "/v1/well-production/cycle-time/cohorts" };
+  }
+}
+
+function formatProductionMonthLine(m: WellProductionMonth): string {
+  const parts: string[] = [];
+  if (typeof m.oil_bbl === "number")
+    parts.push(`oil ${m.oil_bbl.toLocaleString()} bbl`);
+  if (typeof m.oil_bpd === "number")
+    parts.push(`(${m.oil_bpd.toLocaleString()} b/d)`);
+  if (typeof m.gas_mcf === "number")
+    parts.push(`gas ${m.gas_mcf.toLocaleString()} mcf`);
+  if (typeof m.water_bbl === "number")
+    parts.push(`water ${m.water_bbl.toLocaleString()} bbl`);
+  if (typeof m.boe === "number") parts.push(`${m.boe.toLocaleString()} boe`);
+  if (typeof m.days_producing === "number")
+    parts.push(`${m.days_producing} days`);
+  if (m.source) parts.push(`[${m.source}]`);
+  return parts.join(" · ") || "(no data)";
+}
+
+/**
+ * Format a well-production API payload for the given view (#31).
+ * Always ends with the beta coverage note. Exported for tests.
+ */
+export function formatWellProduction(
+  view: WellProductionView,
+  data: Record<string, unknown>,
+): string {
+  let text = `# US Well Production (${view})\n\n`;
+
+  if (view === "summary") {
+    const d = data as WellProductionSummaryData;
+    if (d.national) {
+      const n = d.national;
+      const reported =
+        (typeof n.oil_bbl === "number" && n.oil_bbl > 0) ||
+        (typeof n.gas_mcf === "number" && n.gas_mcf > 0);
+      text += `## National (${n.period ?? "latest"})\n`;
+      text += reported
+        ? `- ${formatProductionMonthLine(n)}\n`
+        : `- Not yet reported for ${n.period ?? "the current period"} (national figures lag; see top states below).\n`;
+      text += `\n`;
+    }
+    if (d.top_states?.length) {
+      text += `## Top Producing States\n`;
+      for (const s of d.top_states) {
+        text += `- **${s.state}** (${s.period}): ${formatProductionMonthLine(s)}\n`;
+      }
+    }
+  } else if (view === "states") {
+    const d = data as WellProductionStatesData;
+    text += `Period ${d.period ?? "latest"} — ${d.count ?? d.states?.length ?? 0} states reporting.\n\n`;
+    for (const s of d.states ?? []) {
+      text += `- **${s.state}**: ${formatProductionMonthLine(s)}\n`;
+    }
+  } else if (view === "state" || view === "well") {
+    const d = data as WellProductionSeriesData;
+    if (view === "well") {
+      text += `**Well**: ${d.well_name ?? "n/a"} · **Operator**: ${d.operator ?? "n/a"} · **API #**: ${d.api_number ?? "n/a"} · **State**: ${d.state ?? "n/a"}\n\n`;
+    } else {
+      text += `**State**: ${d.state ?? "n/a"}`;
+      if (d.period?.start || d.period?.end) {
+        text += ` · **Window**: ${d.period?.start ?? "?"} → ${d.period?.end ?? "?"}`;
+      }
+      text += `\n\n`;
+    }
+    text += `## Monthly Production (${d.count ?? d.data?.length ?? 0} months)\n`;
+    for (const m of d.data ?? []) {
+      text += `- **${m.period}**: ${formatProductionMonthLine(m)}\n`;
+    }
+  } else if (view === "top_producers") {
+    const d = data as WellProductionTopProducersData;
+    if (d.state) text += `**State**: ${d.state}\n`;
+    if (d.period?.start || d.period?.end) {
+      text += `**Window**: ${d.period?.start ?? "?"} → ${d.period?.end ?? "?"}\n`;
+    }
+    text += `\n## Top Producers (${d.count ?? d.producers?.length ?? 0})\n`;
+    for (const p of d.producers ?? []) {
+      const parts: string[] = [];
+      if (typeof p.total_oil_bbl === "number")
+        parts.push(`oil ${p.total_oil_bbl.toLocaleString()} bbl`);
+      if (typeof p.total_gas_mcf === "number")
+        parts.push(`gas ${p.total_gas_mcf.toLocaleString()} mcf`);
+      if (typeof p.months_producing === "number")
+        parts.push(`${p.months_producing} months`);
+      text += `- **${p.well_name ?? p.api_number}** — ${p.operator ?? "unknown operator"} (API ${p.api_number}): ${parts.join(" · ")}\n`;
+    }
+  } else {
+    // cycle_time / cohorts — nested stats objects; render as JSON.
+    text += "```json\n" + JSON.stringify(data, null, 2) + "\n```\n";
+  }
+
+  text += `\n${WELL_PRODUCTION_BETA_NOTE}`;
+  return text;
+}
+
+server.registerTool(
+  "opa_get_well_production",
+  {
+    title: "Get Well Production",
+    description:
+      "Get US oil & gas well production data (BETA coverage: monthly state-level production from EIA + selected state regulators, and well-level histories for selected states only — NOT complete US well-level production). Views: summary (national + top states), states (all reporting states, latest month), state (monthly history for one state), well (monthly history for one well by 14-digit API number), top_producers (highest-output wells, optionally by state), cycle_time (permit-to-production cycle time stats, optionally by state), cohorts (cycle times by spud quarter). Use when the user asks about oil/gas production volumes by state or well, top producing wells, or drill-to-production cycle times. Requires a paid plan with energy intelligence access.",
+    inputSchema: {
+      view: z
+        .enum(WELL_PRODUCTION_VIEWS)
+        .default("summary")
+        .describe(
+          "Which view to return: summary (national + top states), states (all reporting states), state (one state's monthly history — requires 'state'), well (one well's monthly history — requires 'api_number'), top_producers, cycle_time, or cohorts. Default: summary.",
+        ),
+      state: z
+        .string()
+        .optional()
+        .describe(
+          "US state name or 2-letter code (e.g., 'Texas', 'TX'). Required for the state view; optional filter for top_producers and cycle_time.",
+        ),
+      api_number: z
+        .string()
+        .optional()
+        .describe(
+          "14-digit API well number (e.g., '42329447130000'). Required for the well view.",
+        ),
+    },
+    annotations: READ_TOOL_ANNOTATIONS,
+  },
+  async ({ view, state, api_number }) => {
+    if (!getApiKey()) return keylessTeaserResult("opa_get_well_production");
+
+    const mapped = wellProductionEndpoint(view, { state, api_number });
+    if ("error" in mapped) return errorResult(mapped.error);
+
+    const response = await makeApiRequest<ApiResponse<Record<string, unknown>>>(
+      mapped.endpoint,
+    );
+
+    if (!response || response.status !== "success") {
+      if (view === "state") {
+        return errorResult(
+          `No well production data available for '${state}'. Beta coverage is limited to states reporting via EIA or selected state regulators — try the states view to see which states currently report. This also requires a paid plan with energy intelligence access.`,
+        );
+      }
+      if (view === "well") {
+        return errorResult(
+          `No production history found for API number '${api_number}'. Well-level coverage is beta and limited to selected states — the number may be valid but outside current coverage. This also requires a paid plan with energy intelligence access.`,
+        );
+      }
+      return errorResult(
+        "Well production data not available. This requires a paid plan with energy intelligence access.",
+      );
+    }
+
+    return textResult(formatWellProduction(view, response.data));
   },
 );
 


### PR DESCRIPTION
## What

### #31 — `opa_get_well_production` (new tool, 27 total)
- Maps all `/v1/well-production*` views per the issue: `summary`, `states`, `state` (per-state monthly history), `well` (per-well history by 14-digit API number), `top_producers`, `cycle_time`, `cohorts`.
- State filter supported where verified live: `state`, `top_producers`, `cycle_time`.
- **Beta coverage caveats** in the tool description, keyless teaser, and appended to every formatted response — never claims complete US well-level production.
- Negative paths covered: keyless teaser, 402 entitlement gate (central `ApiGateError` + upgrade link), unsupported state, state without data (coverage-aware 404 message), invalid API number (rejected before any API call), generic API errors.

### #31 — stale drilling endpoint
`/v1/drilling/latest` is **still live** but now serves `{ rig_counts, frac_spread_count, well_permits: { last_30d, by_state }, duc_wells_total, deltas, last_updated }` (verified against prod 2026-07-13). The old formatter assumed the retired `total_wells`/`active_rigs`/`region_breakdown` shape, so **every keyed `opa_get_drilling` call crashed** on `data.total_wells.toLocaleString()`. Rewrote the formatter for the current contract (kept the endpoint), updated the interface/description/teaser, and pinned the new shape in the live smoke script.

### #10 — 402/x402 boundary note
Added a README "Pricing Boundary (HTTP 402)" section: MCP server + demo mode stay open, premium/high-volume data sits behind the plan gate, the API answers with exact-limit 402/403/429 bodies that this server surfaces verbatim + upgrade link, and x402 per-request micropayments are not currently supported.

### Hygiene
- `npm audit fix`: 8 vulnerabilities (3 high, all in the dev-only vite/vitest chain) → **0**.
- Added `.github/dependabot.yml` (weekly npm + github-actions, dev-deps grouped).

## Test evidence
- `npm test`: **99 tests pass** (was 78; +21 new covering endpoint mapping, formatting incl. beta-caveat-on-every-view, and all negative paths).
- `npm run build`: clean.
- Live endpoint verification (prod, keyed): all 7 well-production routes probed; state filters verified; error shapes captured (`DATA_NOT_AVAILABLE` 404, `INVALID_PARAMETER` 400).
- Local MCP stdio smoke (built server, real key): 27 tools listed, `opa_get_well_production` summary/state/cycle_time return formatted non-empty responses with the beta caveat, `opa_get_drilling` renders the live shape, invalid API number and unsupported state rejected with actionable messages.
- `scripts/live-smoke.mjs` extended with `/v1/well-production` and `/v1/drilling/latest` contract checks (runs in CI live-tests workflow).

## Note for reviewer
`GET /v1/well-production/top-producers` **without** a `state` param returns HTTP 500 in prod (works with `?state=TX`) — backend bug in oilpriceapi-api, not addressed here; the tool degrades to a clean error result if hit.

No version bump / no npm publish — publishing happens via the release workflow when a maintainer cuts a release.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a beta well production tool with views for summaries, state data, individual wells, top producers, cycle times, and cohorts.
  - Updated drilling results to display current snapshot data.
  - Added validation, clearer errors, and beta coverage notices.
  - Expanded the catalog from 26 to 27 tools.

- **Documentation**
  - Updated the tool catalog, descriptions, and pricing boundary guidance.
  - Documented upgrade responses and machine-readable access limits.

- **Testing**
  - Expanded coverage for well production, drilling, validation, formatting, and plan-gated access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->