### PR TITLE
Send MCP client attribution headers

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,6 +21,8 @@ import {
   SIGNUP_URL,
   UPGRADE_URL,
   createSandboxServer,
+  CLIENT_MARKER,
+  MCP_VERSION,
 } from "../index.js";
 
 // ---------------------------------------------------------------------------
@@ -590,6 +592,8 @@ describe("makeAuthRequest - request shaping", () => {
     expect(init.headers["Content-Type"]).toBe("application/json");
     expect(init.headers["X-OPA-Source"]).toBe("mcp");
     expect(init.headers["X-OPA-Tool"]).toBe("opa_create_price_subscription");
+    expect(init.headers["X-Api-Client"]).toBe(CLIENT_MARKER);
+    expect(init.headers["X-Client-Version"]).toBe(MCP_VERSION);
     expect(JSON.parse(init.body)).toEqual({
       codes: ["BRENT_CRUDE_USD"],
       interval_seconds: 3600,
@@ -705,6 +709,8 @@ describe("demo mode (#16) - fetchDemoPrices", () => {
     const [url, init] = mockFetch.mock.calls[0];
     expect(String(url)).toContain("/v1/demo/prices");
     expect(init.headers.Authorization).toBeUndefined();
+    expect(init.headers["X-Api-Client"]).toBe(CLIENT_MARKER);
+    expect(init.headers["X-Client-Version"]).toBe(MCP_VERSION);
   });
 
   it("returns null when the demo endpoint is unreachable", async () => {
@@ -980,6 +986,8 @@ describe("keyed behavior unchanged", () => {
     expect(String(url)).toContain("/v1/prices/latest?by_code=BRENT_CRUDE_USD");
     expect(String(url)).not.toContain("/v1/demo/");
     expect(init.headers.Authorization).toBe("Bearer test-key-123");
+    expect(init.headers["X-Api-Client"]).toBe(CLIENT_MARKER);
+    expect(init.headers["X-Client-Version"]).toBe(MCP_VERSION);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,17 @@ import { z } from "zod";
 // API Configuration
 const API_BASE =
   process.env.OILPRICEAPI_BASE_URL || "https://api.oilpriceapi.com";
-export const USER_AGENT = "oilpriceapi-mcp/2.4.2";
+export const MCP_VERSION = "2.4.2";
+export const CLIENT_MARKER = `oilpriceapi-mcp/${MCP_VERSION}`;
+export const USER_AGENT = CLIENT_MARKER;
+
+export function clientAttributionHeaders(): Record<string, string> {
+  return {
+    "User-Agent": USER_AGENT,
+    "X-Api-Client": CLIENT_MARKER,
+    "X-Client-Version": MCP_VERSION,
+  };
+}
 
 /**
  * Get the API key from the environment. Read dynamically (not captured at
@@ -704,7 +714,7 @@ export async function makeApiRequest<T>(
   fetchFn: typeof fetch = fetch,
 ): Promise<T | null> {
   const headers: Record<string, string> = {
-    "User-Agent": USER_AGENT,
+    ...clientAttributionHeaders(),
     Accept: "application/json",
   };
 
@@ -811,7 +821,7 @@ export async function makeAuthRequest(
   const { method = "GET", body, headers: extraHeaders } = options;
 
   const headers: Record<string, string> = {
-    "User-Agent": USER_AGENT,
+    ...clientAttributionHeaders(),
     Accept: "application/json",
     // The API accepts the customer API key as a bearer token.
     Authorization: `Bearer ${getApiKey()}`,
@@ -1008,7 +1018,7 @@ export async function fetchDemoPrices(
 ): Promise<DemoPrice[] | null> {
   try {
     const response = await fetchFn(`${API_BASE}/v1/demo/prices`, {
-      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      headers: { ...clientAttributionHeaders(), Accept: "application/json" },
     });
     if (!response.ok) return null;
     const payload = (await response.json()) as ApiResponse<{


### PR DESCRIPTION
## Summary
- align the MCP runtime marker with package version 2.4.1
- add shared MCP client attribution headers: X-Api-Client and X-Client-Version
- send those headers on demo, read, and authenticated request helpers
- add regression coverage for the marker headers

Supports OilpriceAPI/oilpriceapi-api#4607 and pairs with OilpriceAPI/oilpriceapi-api#4609.

## Verification
- npm ci
- npm test (70 passed)
- npm run build
- git diff --check

## Note
- npm ci reports existing dependency audit findings: 5 moderate and 3 high. This PR does not change dependency versions.