### PR TITLE
Allow MCP client marker override

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -989,6 +989,26 @@ describe("keyed behavior unchanged", () => {
     expect(init.headers["X-Api-Client"]).toBe(CLIENT_MARKER);
     expect(init.headers["X-Client-Version"]).toBe(MCP_VERSION);
   });
+
+  it("allows wrapper integrations to override the explicit client marker", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    vi.stubEnv("OILPRICEAPI_CLIENT_MARKER", "oilpriceapi-gemini/1.0.0");
+
+    const mockPayload = { status: "success", data: { price: 85.0 } };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockPayload,
+      headers: { get: () => null },
+    });
+
+    await makeApiRequest("/v1/prices/latest", mockFetch as typeof fetch);
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers["User-Agent"]).toBe(CLIENT_MARKER);
+    expect(init.headers["X-Api-Client"]).toBe("oilpriceapi-gemini/1.0.0");
+    expect(init.headers["X-Client-Version"]).toBe("1.0.0");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,11 +51,26 @@ export const MCP_VERSION = "2.4.2";
 export const CLIENT_MARKER = `oilpriceapi-mcp/${MCP_VERSION}`;
 export const USER_AGENT = CLIENT_MARKER;
 
+function configuredClientMarker(): string {
+  const marker = process.env.OILPRICEAPI_CLIENT_MARKER?.trim();
+  return marker || CLIENT_MARKER;
+}
+
+function configuredClientVersion(marker: string): string {
+  const version = process.env.OILPRICEAPI_CLIENT_VERSION?.trim();
+  if (version) return version;
+
+  const match = marker.match(/\/v?([^/]+)$/);
+  return match?.[1] || MCP_VERSION;
+}
+
 export function clientAttributionHeaders(): Record<string, string> {
+  const marker = configuredClientMarker();
+
   return {
     "User-Agent": USER_AGENT,
-    "X-Api-Client": CLIENT_MARKER,
-    "X-Client-Version": MCP_VERSION,
+    "X-Api-Client": marker,
+    "X-Client-Version": configuredClientVersion(marker),
   };
 }
 


### PR DESCRIPTION
## Summary
- allow wrapper integrations to override X-Api-Client with OILPRICEAPI_CLIENT_MARKER
- infer X-Client-Version from OILPRICEAPI_CLIENT_VERSION or the marker suffix
- keep User-Agent as the MCP package marker so base MCP usage remains identifiable
- add regression coverage for Gemini-style marker override

Pairs with OilpriceAPI/oilpriceapi-api#4609, which configures the Gemini extension marker.

## Verification
- npm test (157 passed)
- npm run build
- git diff --check