### PR TITLE
chore: release MCP server 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi-mcp",
-      "version": "2.4.2",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "mcpName": "io.github.OilpriceAPI/mcp-server",
   "description": "The energy commodity MCP server. Real-time oil, gas, and commodity prices for Claude, Cursor, and any MCP client.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.OilpriceAPI/mcp-server",
-  "description": "Real-time oil, gas & commodity prices. 26 tools: spot, history, futures, alerts, market briefs.",
+  "description": "Real-time oil, gas & commodity data. 27 tools: spot, futures, drilling, wells, alerts.",
   "repository": {
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"
   },
-  "version": "2.4.2",
+  "version": "2.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "oilpriceapi-mcp",
-      "version": "2.4.2",
+      "version": "2.5.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * OilPriceAPI MCP Server v2.4.2
+ * OilPriceAPI MCP Server v2.5.0
  *
  * The energy commodity MCP server. Real-time oil, gas, and commodity prices
  * for Claude, Cursor, VS Code, and any MCP-compatible client.
@@ -47,7 +47,7 @@ import { z } from "zod";
 // API Configuration
 const API_BASE =
   process.env.OILPRICEAPI_BASE_URL || "https://api.oilpriceapi.com";
-export const MCP_VERSION = "2.4.2";
+export const MCP_VERSION = "2.5.0";
 export const CLIENT_MARKER = `oilpriceapi-mcp/${MCP_VERSION}`;
 export const USER_AGENT = CLIENT_MARKER;
 
@@ -491,7 +491,7 @@ interface DrillingData {
 
 const server = new McpServer({
   name: "oilpriceapi",
-  version: "2.4.2",
+  version: "2.5.0",
 });
 
 // ---------------------------------------------------------------------------
@@ -3819,7 +3819,7 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("OilPriceAPI MCP Server v2.4.2 running on stdio");
+  console.error("OilPriceAPI MCP Server v2.5.0 running on stdio");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- Bump npm package, lockfile, runtime MCP version, and server registry metadata to 2.5.0.
- Update MCP registry description from 26 to 27 tools after the well-production tool merge.

## Verification
- node version consistency check for package.json/package-lock.json/server.json
- npm test (200 passed)
- npm run build
- git diff --check