### PR TITLE
feat: opa_get_fuel_surcharge — published LTL carrier fuel surcharges (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Backed by [OilPriceAPI](https://oilpriceapi.com) — the commodity price API beh
 
 ## Features
 
-- **27 Tools** — 18 read tools (spot prices, history, futures, marine fuels, rig counts, diesel by state, storage, OPEC production, forecasts, EIA oil inventories, well permits, well production, refining spreads) plus 4 authenticated price-alert tools (create/list/delete persistent alerts + trigger activity) and 5 agent tools (multi-commodity market briefs, persistent price watches)
+- **28 Tools** — 19 read tools (spot prices, history, futures, marine fuels, rig counts, diesel by state, LTL carrier fuel surcharges, storage, OPEC production, forecasts, EIA oil inventories, well permits, well production, refining spreads) plus 4 authenticated price-alert tools (create/list/delete persistent alerts + trigger activity) and 5 agent tools (multi-commodity market briefs, persistent price watches)
 - **5 Resources** — subscribable price snapshots for Brent, WTI, Natural Gas, Diesel, and all commodities
 - **6 Prompts** — pre-built analyst templates (daily briefing, spread analysis, gas markets, commodity report, diesel costs, supply analysis)
 - **Natural language** — ask for "brent oil" or "natural gas", not codes
@@ -169,6 +169,7 @@ All tools are prefixed with `opa_` to avoid name collisions when multiple MCP se
 | `opa_get_rig_counts`      | Baker Hughes US rig count with week-over-week change                                            |
 | `opa_get_drilling`        | Drilling snapshot: rig counts, frac spreads, 30-day permits, DUCs                               |
 | `opa_get_diesel_by_state` | AAA retail diesel price for any US state (50 states + DC)                                       |
+| `opa_get_fuel_surcharge`  | Published LTL carrier fuel surcharge % (ODFL, Saia, Estes, FedEx Freight, XPO, ABF, ...) tied to the DOE diesel index |
 | `opa_get_storage`         | Cushing and SPR oil storage/inventory levels                                                    |
 | `opa_get_opec_production` | OPEC country-level production data                                                              |
 | `opa_get_forecasts`       | EIA STEO energy price forecasts                                                                 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi-mcp",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "mcpName": "io.github.OilpriceAPI/mcp-server",
   "description": "The energy commodity MCP server. Real-time oil, gas, and commodity prices for Claude, Cursor, and any MCP client.",
   "type": "module",

--- a/scripts/live-smoke.mjs
+++ b/scripts/live-smoke.mjs
@@ -364,6 +364,48 @@ async function main() {
     }
   }
 
+  await sleep(RATE_LIMIT_MS);
+
+  // 6b. LTL fuel surcharge — GET /v1/fuel-surcharge (#43)
+  // What opa_get_fuel_surcharge (all-carriers view) builds. The endpoint
+  // ships in a parallel API sprint (oilpriceapi-api#4767/#4772), so a 404 is
+  // the documented not-yet-deployed state — the MCP tool returns a clear
+  // "not yet available" message for it — and is a SKIP, not a failure. Once
+  // deployed, this check requires 200 + data.carriers[] with a numeric
+  // surcharge_percent. Also TOLERANT of 402/403 (plan-gated dataset).
+  try {
+    const { status, body } = await getJson("/v1/fuel-surcharge");
+    rateLimitGuard(status, "GET /v1/fuel-surcharge");
+    planGateGuard(status, "GET /v1/fuel-surcharge");
+    if (status === 404) {
+      console.log(
+        "SKIP: GET /v1/fuel-surcharge -> 404 — endpoint not yet deployed (oilpriceapi-api#4772); the MCP tool reports 'not yet available' for this state.",
+      );
+    } else {
+      assert(status === 200, `fuel-surcharge expected 200/404, got ${status}`);
+      const carriers = body && body.data && body.data.carriers;
+      assert(
+        Array.isArray(carriers) && carriers.length > 0,
+        `fuel-surcharge missing data.carriers[]: ${JSON.stringify(body).slice(0, 300)}`,
+      );
+      const first = carriers[0];
+      assert(
+        typeof first.carrier === "string" &&
+          typeof first.surcharge_percent === "number" &&
+          Number.isFinite(first.surcharge_percent),
+        "fuel-surcharge first carrier missing carrier/surcharge_percent",
+      );
+      console.log(
+        `PASS: GET /v1/fuel-surcharge -> 200, ${carriers.length} carrier(s), ${first.carrier} @ ${first.surcharge_percent}%`,
+      );
+    }
+  } catch (err) {
+    failures = handleCheckError(err, failures);
+    if (!(err instanceof RateLimited) && !(err instanceof PlanGated)) {
+      console.error(`FAIL (fuel-surcharge): ${err.message}`);
+    }
+  }
+
   // 7. WRITE round-trip (opt-in) — create -> poll events -> delete.
   // Guarded behind SMOKE_WRITE_SUBSCRIPTIONS=1 so the default run never writes
   // to prod. When enabled, the created watch is ALWAYS deleted in the same run

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.OilpriceAPI/mcp-server",
-  "description": "Real-time oil, gas & commodity data. 27 tools: spot, futures, drilling, wells, alerts.",
+  "description": "Real-time oil, gas & commodity data. 28 tools: spot, futures, drilling, wells, alerts.",
   "repository": {
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"
   },
-  "version": "2.5.0",
+  "version": "2.6.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "oilpriceapi-mcp",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -26,6 +26,11 @@ import {
   formatDrillingData,
   WELL_PRODUCTION_VIEWS,
   WELL_PRODUCTION_BETA_NOTE,
+  resolveCarrierSlug,
+  fuelSurchargeEndpoint,
+  formatFuelSurcharge,
+  FUEL_SURCHARGE_CARRIER_ALIASES,
+  FUEL_SURCHARGE_PROVENANCE_NOTE,
   CLIENT_MARKER,
   MCP_VERSION,
 } from "../index.js";
@@ -1046,8 +1051,8 @@ describe("tool registration metadata", () => {
   const DELETE_TOOLS = ["opa_delete_price_alert", "opa_delete_subscription"];
   const WRITE_TOOLS = new Set([...CREATE_TOOLS, ...DELETE_TOOLS]);
 
-  it("registers exactly 27 tools", () => {
-    expect(Object.keys(tools)).toHaveLength(27);
+  it("registers exactly 28 tools", () => {
+    expect(Object.keys(tools)).toHaveLength(28);
   });
 
   it("registers all four write tools (creates + deletes)", () => {
@@ -1537,6 +1542,293 @@ describe("keylessTeaserResult covers opa_get_well_production (#31)", () => {
     const text = keylessTeaserResult("opa_get_well_production").content[0].text;
     expect(text).toContain("opa_get_well_production");
     expect(text).toContain("beta coverage");
+    expect(text).toContain(SIGNUP_URL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #43 — LTL carrier fuel surcharge (opa_get_fuel_surcharge)
+// ---------------------------------------------------------------------------
+
+describe("resolveCarrierSlug (#43)", () => {
+  it("maps common carrier names and abbreviations to slugs", () => {
+    expect(resolveCarrierSlug("ODFL")).toBe("odfl");
+    expect(resolveCarrierSlug("Old Dominion")).toBe("odfl");
+    expect(resolveCarrierSlug("old dominion freight line")).toBe("odfl");
+    expect(resolveCarrierSlug("Saia")).toBe("saia");
+    expect(resolveCarrierSlug("Estes Express")).toBe("estes");
+    expect(resolveCarrierSlug("FedEx Freight")).toBe("fedex-freight");
+    expect(resolveCarrierSlug("fedex")).toBe("fedex-freight");
+    expect(resolveCarrierSlug("XPO")).toBe("xpo");
+    expect(resolveCarrierSlug("ArcBest")).toBe("abf");
+    expect(resolveCarrierSlug("R+L Carriers")).toBe("rl-carriers");
+    expect(resolveCarrierSlug("TForce Freight")).toBe("tforce");
+    expect(resolveCarrierSlug("SEFL")).toBe("southeastern");
+  });
+
+  it("slugifies unknown carriers instead of rejecting them", () => {
+    expect(resolveCarrierSlug("Dayton Freight")).toBe("dayton-freight");
+    expect(resolveCarrierSlug("  A. Duie Pyle  ")).toBe("a-duie-pyle");
+  });
+
+  it("every alias value is already a canonical slug (aliases don't chain)", () => {
+    for (const slug of Object.values(FUEL_SURCHARGE_CARRIER_ALIASES)) {
+      expect(resolveCarrierSlug(slug)).toBe(slug);
+    }
+  });
+});
+
+describe("fuelSurchargeEndpoint (#43) - request mapping", () => {
+  it("maps no carrier to the all-carriers list endpoint", () => {
+    expect(fuelSurchargeEndpoint()).toBe("/v1/fuel-surcharge");
+    expect(fuelSurchargeEndpoint(undefined)).toBe("/v1/fuel-surcharge");
+    expect(fuelSurchargeEndpoint("   ")).toBe("/v1/fuel-surcharge");
+  });
+
+  it("maps a carrier to its /latest endpoint via the slug resolver", () => {
+    expect(fuelSurchargeEndpoint("ODFL")).toBe(
+      "/v1/fuel-surcharge/odfl/latest",
+    );
+    expect(fuelSurchargeEndpoint("FedEx Freight")).toBe(
+      "/v1/fuel-surcharge/fedex-freight/latest",
+    );
+  });
+});
+
+// Contract fixture from oilpriceapi-api#4772 (shared API contract).
+const FUEL_SURCHARGE_CONTRACT_ENTRY = {
+  carrier: "odfl",
+  carrier_name: "Old Dominion Freight Line",
+  mode: "ltl",
+  surcharge_percent: 33.9,
+  effective_date: "2026-07-13",
+  doe_diesel_price: 3.756,
+  diesel_band: { min: 3.7, max: 3.79 },
+  source: "https://www.odfl.com/us/en/resources/fuel-surcharge.html",
+  retrieved_at: "2026-07-15T12:00:00Z",
+};
+
+describe("formatFuelSurcharge (#43) - formatting", () => {
+  it("formats the all-carriers list payload from the #4772 contract", () => {
+    const text = formatFuelSurcharge({
+      carriers: [FUEL_SURCHARGE_CONTRACT_ENTRY],
+    });
+
+    expect(text).toContain("LTL Carrier Fuel Surcharges (1 carriers)");
+    expect(text).toContain("Old Dominion Freight Line");
+    expect(text).toContain("`odfl`");
+    expect(text).toContain("33.9%");
+    expect(text).toContain("effective 2026-07-13");
+    expect(text).toContain("$3.70–$3.79/gal");
+    expect(text).toContain("DOE diesel: $3.756/gal");
+    expect(text).toContain(
+      "https://www.odfl.com/us/en/resources/fuel-surcharge.html",
+    );
+    expect(text).toContain("retrieved 2026-07-15T12:00:00Z");
+    expect(text).toContain(FUEL_SURCHARGE_PROVENANCE_NOTE);
+  });
+
+  it("formats a single-carrier /latest payload (same shape, no carriers[])", () => {
+    const text = formatFuelSurcharge(FUEL_SURCHARGE_CONTRACT_ENTRY);
+
+    expect(text).toContain("# Fuel Surcharge — Old Dominion Freight Line");
+    expect(text).toContain("33.9%");
+    expect(text).toContain(FUEL_SURCHARGE_PROVENANCE_NOTE);
+  });
+
+  it("tolerates missing optional fields without throwing or fabricating", () => {
+    const text = formatFuelSurcharge({
+      carriers: [{ carrier: "saia" }],
+    });
+
+    expect(text).toContain("saia");
+    expect(text).toContain("(surcharge not reported)");
+    expect(text).not.toContain("NaN");
+    expect(text).not.toContain("undefined");
+    expect(text).toContain(FUEL_SURCHARGE_PROVENANCE_NOTE);
+  });
+
+  it("keeps serving stale values with their TRUE retrieved_at (honest staleness)", () => {
+    // The contract mandates: stale carrier fetch => last value with its real
+    // effective_date/retrieved_at, never faked freshness. The formatter must
+    // surface whatever timestamps the API reports, unmodified.
+    const stale = {
+      ...FUEL_SURCHARGE_CONTRACT_ENTRY,
+      effective_date: "2026-05-04",
+      retrieved_at: "2026-05-06T12:00:00Z",
+    };
+    const text = formatFuelSurcharge({ carriers: [stale] });
+    expect(text).toContain("effective 2026-05-04");
+    expect(text).toContain("retrieved 2026-05-06T12:00:00Z");
+  });
+});
+
+describe("opa_get_fuel_surcharge (#43) - tool handler paths", () => {
+  const server = createSandboxServer();
+  const tools = (
+    server as unknown as {
+      _registeredTools: Record<
+        string,
+        {
+          handler: (
+            args: Record<string, unknown>,
+            extra: Record<string, unknown>,
+          ) => Promise<{
+            content: Array<{ type: string; text: string }>;
+            isError?: boolean;
+          }>;
+        }
+      >;
+    }
+  )._registeredTools;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the keyless teaser when no API key is configured", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "");
+    vi.stubEnv("OIL_PRICE_API_KEY", "");
+
+    const result = await tools.opa_get_fuel_surcharge.handler({}, {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("opa_get_fuel_surcharge");
+    expect(result.content[0].text).toContain(SIGNUP_URL);
+    expect(result.content[0].text).not.toContain("Authentication failed");
+  });
+
+  it("keyed all-carriers call formats the contract shape end-to-end", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({
+        status: "success",
+        data: { carriers: [FUEL_SURCHARGE_CONTRACT_ENTRY] },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await tools.opa_get_fuel_surcharge.handler({}, {});
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Old Dominion Freight Line");
+    expect(result.content[0].text).toContain("33.9%");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toContain("/v1/fuel-surcharge");
+  });
+
+  it("keyed single-carrier call hits the /{carrier}/latest endpoint", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({
+        status: "success",
+        data: FUEL_SURCHARGE_CONTRACT_ENTRY,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await tools.opa_get_fuel_surcharge.handler(
+      { carrier: "Old Dominion" },
+      {},
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain(
+      "# Fuel Surcharge — Old Dominion Freight Line",
+    );
+    expect(String(fetchSpy.mock.calls[0][0])).toContain(
+      "/v1/fuel-surcharge/odfl/latest",
+    );
+  });
+
+  it("returns a clear 'not yet available' error when the endpoint 404s (not yet deployed) — never a crash, never fabricated data", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        headers: { get: () => null },
+        text: async () => JSON.stringify({ error: "Not found" }),
+      }),
+    );
+
+    const result = await tools.opa_get_fuel_surcharge.handler({}, {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "Fuel surcharge data is not yet available",
+    );
+    // Never fabricate a surcharge value on the unavailable path.
+    expect(result.content[0].text).not.toMatch(/\d+\.\d+%/);
+  });
+
+  it("returns a carrier-aware error on 404 for a specific carrier", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        headers: { get: () => null },
+        text: async () =>
+          JSON.stringify({ error: "Unknown carrier: dayton-freight" }),
+      }),
+    );
+
+    const result = await tools.opa_get_fuel_surcharge.handler(
+      { carrier: "Dayton Freight" },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Dayton Freight");
+    expect(result.content[0].text).toContain("without a carrier");
+  });
+
+  it("surfaces the 402 entitlement gate with the upgrade link", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 402,
+        statusText: "Payment Required",
+        headers: { get: () => null },
+        text: async () =>
+          JSON.stringify({
+            message: "Fuel surcharge data requires a paid plan",
+          }),
+      }),
+    );
+
+    // Calling the handler directly bypasses the SDK's error-to-result
+    // conversion, so the ApiGateError surfaces as a rejection here.
+    await expect(
+      tools.opa_get_fuel_surcharge.handler({}, {}),
+    ).rejects.toMatchObject({
+      name: "ApiGateError",
+      status: 402,
+      message: expect.stringContaining(UPGRADE_URL),
+    });
+  });
+});
+
+describe("keylessTeaserResult covers opa_get_fuel_surcharge (#43)", () => {
+  it("returns the fuel-surcharge teaser with LTL + DOE wording", () => {
+    const text = keylessTeaserResult("opa_get_fuel_surcharge").content[0].text;
+    expect(text).toContain("opa_get_fuel_surcharge");
+    expect(text).toContain("LTL");
+    expect(text).toContain("DOE");
     expect(text).toContain(SIGNUP_URL);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * OilPriceAPI MCP Server v2.5.0
+ * OilPriceAPI MCP Server v2.6.0
  *
  * The energy commodity MCP server. Real-time oil, gas, and commodity prices
  * for Claude, Cursor, VS Code, and any MCP-compatible client.
@@ -17,11 +17,12 @@
  * limit/feature gate hit by the API plus an upgrade link (see ApiGateError in
  * makeApiRequest and alertHttpError for the authenticated tools).
  *
- * 27 tools total (opa_ prefixed):
+ * 28 tools total (opa_ prefixed):
  *
- * 18 read-only tools: prices, history, futures, marine fuels, rig counts,
- * drilling, diesel-by-state, storage, OPEC production, forecasts, EIA oil
- * inventories, well permits, well production, refining spreads.
+ * 19 read-only tools: prices, history, futures, marine fuels, rig counts,
+ * drilling, diesel-by-state, LTL carrier fuel surcharges, storage, OPEC
+ * production, forecasts, EIA oil inventories, well permits, well production,
+ * refining spreads.
  *
  * 4 authenticated price-alert tools (opa_*_price_alert / opa_get_alert_triggers):
  * create/list/delete persistent price alerts tied to the user's account and read
@@ -47,7 +48,7 @@ import { z } from "zod";
 // API Configuration
 const API_BASE =
   process.env.OILPRICEAPI_BASE_URL || "https://api.oilpriceapi.com";
-export const MCP_VERSION = "2.5.0";
+export const MCP_VERSION = "2.6.0";
 export const CLIENT_MARKER = `oilpriceapi-mcp/${MCP_VERSION}`;
 export const USER_AGENT = CLIENT_MARKER;
 
@@ -491,7 +492,7 @@ interface DrillingData {
 
 const server = new McpServer({
   name: "oilpriceapi",
-  version: "2.5.0",
+  version: "2.6.0",
 });
 
 // ---------------------------------------------------------------------------
@@ -1321,6 +1322,11 @@ const KEYLESS_TOOL_TEASERS: Record<string, { does: string; example: string }> =
       does: "Returns the AAA average retail diesel price for any US state.",
       example: "Diesel Price — TX: $X.XXX/gallon (24h change ±$0.0XX)",
     },
+    opa_get_fuel_surcharge: {
+      does: "Returns the fuel surcharge percentage each major LTL freight carrier (ODFL, Saia, Estes, FedEx Freight, XPO, ABF, ...) currently publishes, with the effective date, the matched DOE/EIA on-highway diesel price band, the underlying DOE diesel price, and source + retrieval provenance.",
+      example:
+        "Old Dominion Freight Line (odfl): XX.X% — effective YYYY-MM-DD · diesel band $X.XX–$X.XX · DOE diesel $X.XXX/gal",
+    },
     opa_get_storage: {
       does: "Returns oil storage/inventory levels for Cushing, Oklahoma and the US Strategic Petroleum Reserve.",
       example:
@@ -1425,8 +1431,8 @@ export function keylessTeaserResult(toolName: string) {
 }
 
 // =========================================================================
-// READ TOOLS (18 — opa_ prefixed to avoid collisions). Plus 4 authenticated
-// price-alert tools further below, for 22 tools total.
+// READ TOOLS (19 — opa_ prefixed to avoid collisions). Plus 4 authenticated
+// price-alert tools further below, for 23 tools total.
 // =========================================================================
 
 server.registerTool(
@@ -2187,6 +2193,189 @@ server.registerTool(
     text += `\n_Data from [OilPriceAPI](https://oilpriceapi.com)_`;
 
     return textResult(text);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// LTL carrier fuel surcharge (#43) — /v1/fuel-surcharge*
+//
+// Each major LTL freight carrier publishes a weekly fuel-surcharge % tied to
+// the DOE/EIA on-highway diesel index. These tools surface the carrier's own
+// PUBLISHED schedule value — not a computed estimate — with source +
+// retrieved_at provenance (collect freely, claim nothing: we track what the
+// carrier publishes and cite where/when we got it).
+//
+// NOTE: the /v1/fuel-surcharge endpoints ship in a parallel API sprint
+// (oilpriceapi-api#4767/#4772). Until they deploy, the API answers 404 and
+// this tool returns a clear "not yet available" message — never a crash,
+// never fabricated data.
+// ---------------------------------------------------------------------------
+
+/**
+ * Common LTL carrier names/abbreviations → API carrier slug. Anything not in
+ * the map is slugified (lowercased, non-alphanumerics → hyphens) and passed
+ * through; an unknown slug gets a clean not-covered error from the API (404),
+ * which the tool turns into an actionable message.
+ */
+export const FUEL_SURCHARGE_CARRIER_ALIASES: Record<string, string> = {
+  odfl: "odfl",
+  "old dominion": "odfl",
+  "old dominion freight": "odfl",
+  "old dominion freight line": "odfl",
+  saia: "saia",
+  "saia ltl freight": "saia",
+  estes: "estes",
+  "estes express": "estes",
+  "estes express lines": "estes",
+  fedex: "fedex-freight",
+  "fedex freight": "fedex-freight",
+  xpo: "xpo",
+  "xpo logistics": "xpo",
+  abf: "abf",
+  "abf freight": "abf",
+  arcbest: "abf",
+  "r+l": "rl-carriers",
+  "r+l carriers": "rl-carriers",
+  rl: "rl-carriers",
+  "rl carriers": "rl-carriers",
+  averitt: "averitt",
+  "averitt express": "averitt",
+  tforce: "tforce",
+  "tforce freight": "tforce",
+  "t-force": "tforce",
+  southeastern: "southeastern",
+  "southeastern freight": "southeastern",
+  "southeastern freight lines": "southeastern",
+  sefl: "southeastern",
+};
+
+/**
+ * Resolve a carrier name/abbreviation to the API carrier slug (#43).
+ * Exported for tests.
+ */
+export function resolveCarrierSlug(input: string): string {
+  const normalized = input.toLowerCase().trim();
+  const alias = FUEL_SURCHARGE_CARRIER_ALIASES[normalized];
+  if (alias) return alias;
+  // Slugify pass-through: "FedEx Freight" -> "fedex-freight".
+  return normalized.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Map an optional carrier to the fuel-surcharge endpoint (#43).
+ * Exported for tests.
+ */
+export function fuelSurchargeEndpoint(carrier?: string): string {
+  const slug = carrier?.trim() ? resolveCarrierSlug(carrier) : "";
+  return slug ? `/v1/fuel-surcharge/${slug}/latest` : "/v1/fuel-surcharge";
+}
+
+interface FuelSurchargeEntry {
+  carrier?: string;
+  carrier_name?: string;
+  mode?: string;
+  surcharge_percent?: number | null;
+  effective_date?: string;
+  doe_diesel_price?: number | null;
+  diesel_band?: { min?: number | null; max?: number | null } | null;
+  source?: string;
+  retrieved_at?: string;
+}
+
+interface FuelSurchargeListData {
+  carriers?: FuelSurchargeEntry[];
+}
+
+export const FUEL_SURCHARGE_PROVENANCE_NOTE =
+  "_Each percentage is the fuel surcharge the carrier itself publishes (matched to the DOE/EIA on-highway diesel index) — tracked from the carrier's public schedule with source + retrieval time, not a computed estimate. Data from [OilPriceAPI](https://oilpriceapi.com)_";
+
+function formatFuelSurchargeEntry(e: FuelSurchargeEntry): string {
+  const name = e.carrier_name || e.carrier || "Unknown carrier";
+  const slugPart = e.carrier
+    ? ` (\`${e.carrier}\`${e.mode ? `, ${e.mode.toUpperCase()}` : ""})`
+    : "";
+  let text = `- **${name}**${slugPart}: `;
+  text +=
+    typeof e.surcharge_percent === "number"
+      ? `**${e.surcharge_percent.toFixed(1)}%**`
+      : "(surcharge not reported)";
+  if (e.effective_date) text += ` — effective ${e.effective_date}`;
+  const details: string[] = [];
+  const band = e.diesel_band;
+  if (band && (typeof band.min === "number" || typeof band.max === "number")) {
+    const min = typeof band.min === "number" ? `$${band.min.toFixed(2)}` : "?";
+    const max = typeof band.max === "number" ? `$${band.max.toFixed(2)}` : "?";
+    details.push(`Diesel band: ${min}–${max}/gal`);
+  }
+  if (typeof e.doe_diesel_price === "number") {
+    details.push(`DOE diesel: $${e.doe_diesel_price.toFixed(3)}/gal`);
+  }
+  if (e.source) {
+    details.push(
+      `Source: ${e.source}${e.retrieved_at ? ` (retrieved ${e.retrieved_at})` : ""}`,
+    );
+  } else if (e.retrieved_at) {
+    details.push(`Retrieved: ${e.retrieved_at}`);
+  }
+  for (const d of details) text += `\n  - ${d}`;
+  return text;
+}
+
+/**
+ * Format a fuel-surcharge API payload (#43): either the all-carriers list
+ * ({ carriers: [...] }) or a single-carrier object (same entry shape).
+ * Always ends with the provenance note. Exported for tests.
+ */
+export function formatFuelSurcharge(data: Record<string, unknown>): string {
+  const list = data as FuelSurchargeListData;
+  let text: string;
+  if (Array.isArray(list.carriers)) {
+    text = `# LTL Carrier Fuel Surcharges (${list.carriers.length} carriers)\n\n`;
+    text += list.carriers.map(formatFuelSurchargeEntry).join("\n");
+  } else {
+    const entry = data as FuelSurchargeEntry;
+    text = `# Fuel Surcharge — ${entry.carrier_name || entry.carrier || "Carrier"}\n\n`;
+    text += formatFuelSurchargeEntry(entry);
+  }
+  text += `\n\n${FUEL_SURCHARGE_PROVENANCE_NOTE}`;
+  return text;
+}
+
+server.registerTool(
+  "opa_get_fuel_surcharge",
+  {
+    title: "Get LTL Carrier Fuel Surcharge",
+    description:
+      "Get the current published fuel surcharge percentage for major LTL freight carriers — ODFL (Old Dominion), Saia, Estes, FedEx Freight, XPO, ABF/ArcBest, R+L Carriers, Averitt, TForce Freight, Southeastern Freight Lines. Each carrier publishes a weekly fuel surcharge % tied to the DOE/EIA on-highway diesel index; this returns the carrier's own published value (not an estimate) with effective date, the matched diesel price band, the underlying DOE diesel price, and source + retrieved_at provenance. Use when the user asks about fuel surcharges, LTL freight fuel costs, carrier surcharge schedules, freight quoting/auditing, TMS or logistics rate calculations, or shipping cost pass-throughs. Omit 'carrier' to list all covered carriers with their latest %; pass a carrier name or code for one carrier. For the raw DOE diesel price itself use opa_get_price ('diesel') or opa_get_diesel_by_state.",
+    inputSchema: {
+      carrier: z
+        .string()
+        .optional()
+        .describe(
+          "Optional carrier name or code (e.g., 'ODFL', 'Old Dominion', 'Saia', 'Estes', 'FedEx Freight', 'XPO', 'ABF', 'R+L', 'Averitt', 'TForce', 'Southeastern'). Omit to list all covered carriers.",
+        ),
+    },
+    annotations: READ_TOOL_ANNOTATIONS,
+  },
+  async ({ carrier }) => {
+    if (!getApiKey()) return keylessTeaserResult("opa_get_fuel_surcharge");
+
+    const endpoint = fuelSurchargeEndpoint(carrier);
+    const response =
+      await makeApiRequest<ApiResponse<Record<string, unknown>>>(endpoint);
+
+    if (!response || response.status !== "success") {
+      if (carrier?.trim()) {
+        return errorResult(
+          `No fuel surcharge data available for '${carrier}'. Either this carrier is not covered yet, or the fuel-surcharge dataset is not yet available. Call opa_get_fuel_surcharge without a carrier to list covered carriers. Covered-at-launch targets include ODFL, Saia, Estes, FedEx Freight, XPO, and ABF.`,
+        );
+      }
+      return errorResult(
+        "Fuel surcharge data is not yet available — the /v1/fuel-surcharge dataset may not be deployed yet, or may require a paid plan. No surcharge value can be reported (this tool never estimates or fabricates one). Try again later, or see https://oilpriceapi.com for dataset availability.",
+      );
+    }
+
+    return textResult(formatFuelSurcharge(response.data));
   },
 );
 
@@ -3819,7 +4008,7 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("OilPriceAPI MCP Server v2.5.0 running on stdio");
+  console.error("OilPriceAPI MCP Server v2.6.0 running on stdio");
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2371,7 +2371,7 @@ server.registerTool(
         );
       }
       return errorResult(
-        "Fuel surcharge data is not yet available — the /v1/fuel-surcharge dataset may not be deployed yet, or may require a paid plan. No surcharge value can be reported (this tool never estimates or fabricates one). Try again later, or see https://oilpriceapi.com for dataset availability.",
+        "Fuel surcharge data is not yet available — the /v1/fuel-surcharge dataset may not be deployed yet. No surcharge value can be reported (this tool never estimates or fabricates one). Try again later, or see https://oilpriceapi.com for dataset availability.",
       );
     }
 


### PR DESCRIPTION
## Summary

Adds `opa_get_fuel_surcharge` — the LTL carrier fuel-surcharge tool from #43, built against the shared API contract in OilpriceAPI/oilpriceapi-api#4772 (parent: OilpriceAPI/oilpriceapi-api#4767).

- `opa_get_fuel_surcharge()` → `GET /v1/fuel-surcharge` (all covered carriers, latest % each)
- `opa_get_fuel_surcharge(carrier)` → `GET /v1/fuel-surcharge/{slug}/latest` (single carrier)
- Returns: surcharge %, effective date, matched diesel band, underlying DOE diesel price, `source` + `retrieved_at` provenance
- Description is agent-discovery-friendly: names LTL freight, the covered carriers (ODFL, Saia, Estes, FedEx Freight, XPO, ABF/ArcBest, R+L, Averitt, TForce, Southeastern), the DOE/EIA on-highway diesel index, and freight/logistics/TMS quoting-and-auditing use cases (parity+ vs NexusFeed's `ltl_get_fuel_surcharge`, per #43)
- Tool name follows this server's `opa_` prefix convention (README: all tools are `opa_`-prefixed to avoid collisions), so `get_fuel_surcharge` ships as `opa_get_fuel_surcharge`
- Carrier input goes through a name/abbreviation → slug resolver (`"Old Dominion"`/`"ODFL"` → `odfl`, `"FedEx Freight"` → `fedex-freight`, ...) with a slugify pass-through for unlisted carriers
- Rights-safe copy: output states each % is the carrier's own published value with source + retrieval time — collect freely, claim nothing, never an estimate
- Keyless demo mode gets a teaser entry (#16 pattern); 402/403/429 flow through the standard `ApiGateError` upgrade nudge (#17 pattern)

## Endpoints are NOT deployed yet — graceful degradation

`/v1/fuel-surcharge` ships in a parallel API sprint track and returns **404 in production today** (verified: `curl` keyed and unauthenticated both → 404). Handling:

- Tool: a 404/unknown-endpoint (or any non-success) response returns a clear **"Fuel surcharge data is not yet available"** error result — never a crash, never fabricated data. With a `carrier` argument the error is carrier-aware and suggests calling without a carrier to list coverage.
- Live smoke (`scripts/live-smoke.mjs`): new `/v1/fuel-surcharge` check treats 404 as a tolerated **not-yet-deployed SKIP** (mirroring the existing 429/plan-gate SKIP patterns), so CI stays green until the endpoints land — then it pins the contract (200 + `data.carriers[]` + numeric `surcharge_percent`).
- Slug format beyond the contract's `odfl` example is assumed hyphenated (matching the `/v1/futures/ice-brent` convention); if the backend lands different slugs, the 404 path degrades gracefully and the alias map is a one-line fix.

## Version + changelog

- Version bump `2.5.0` → `2.6.0` (`package.json`, `package-lock.json`, `server.json`, `src/index.ts`, tool count 27 → 28). `manifest.json` left untouched, matching the v2.5.0 release convention.
- Changelog follows the repo convention of GitHub release notes — proposed **v2.6.0** notes (for whoever tags the release; per scope this PR does NOT publish to npm/PyPI or submit to MCP directories):
  > **v2.6.0 — LTL carrier fuel surcharge tool**
  > New `opa_get_fuel_surcharge` tool: the fuel surcharge % each major LTL carrier (ODFL, Saia, Estes, FedEx Freight, XPO, ABF, ...) publishes against the DOE/EIA on-highway diesel index, with effective date, diesel band, DOE diesel price, and source/retrieved_at provenance. Degrades to a clear "not yet available" message until the `/v1/fuel-surcharge` API endpoints deploy (oilpriceapi-api#4772).

## Test evidence

`npm run build && npm test` (vitest):

```
Test Files  2 passed (2)
     Tests  232 passed (232)
```

16 new `#43` tests (×2: run against both `src/` and the compiled `build/` copy), mirroring the #31 well-production test style:

- `resolveCarrierSlug`: alias mapping, slugify pass-through, alias values are canonical (no chaining)
- `fuelSurchargeEndpoint`: no carrier → list endpoint; carrier → `/{slug}/latest`; blank carrier → list
- `formatFuelSurcharge`: #4772 contract fixture (list + single-carrier shapes), missing-field tolerance (no `NaN`/`undefined`/fabrication), honest staleness (true `effective_date`/`retrieved_at` surfaced unmodified)
- Tool handler (mocked HTTP): keyless teaser, keyed list + single-carrier end-to-end, 404 → "not yet available" (asserts no fabricated % on that path), carrier-aware 404, 402 gate with upgrade link
- Teaser coverage for the new tool
- Existing tool-registration metadata suite now asserts exactly 28 tools with correct annotations

Not verifiable until the API deploys: live end-to-end against production (per #43 acceptance, "once endpoints deploy") — the new smoke check flips from SKIP to a real contract assertion at that point.

Part of OilpriceAPI/oilpriceapi-api#4767, closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **LTL carrier fuel surcharge** tool (**all-carriers** and **carrier-specific** views).
  - Shows surcharge percentages with effective dates, DOE diesel index band, and source timestamps.
  - Includes keyless teaser behavior and improved handling for “not yet available” (404) and access-restricted (402) scenarios.

- **Documentation**
  - Updated tool reference and feature summary to reflect **28 tools** and added the new fuel surcharge tool details.

- **Release**
  - Bumped release/server version to **2.6.0**.

- **Tests / Quality**
  - Added a live smoke check for the fuel surcharge endpoint and expanded related unit coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->