### PR TITLE
feat: add fuel surcharge MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Backed by [OilPriceAPI](https://oilpriceapi.com) — the commodity price API beh
 
 ## Features
 
-- **28 Tools** — 19 read tools (spot prices, history, futures, marine fuels, rig counts, diesel by state, LTL carrier fuel surcharges, storage, OPEC production, forecasts, EIA oil inventories, well permits, well production, refining spreads) plus 4 authenticated price-alert tools (create/list/delete persistent alerts + trigger activity) and 5 agent tools (multi-commodity market briefs, persistent price watches)
+- **28 Tools** — 19 read tools (spot prices, history, futures, marine fuels, rig counts, diesel by state, LTL and parcel fuel surcharges, storage, OPEC production, forecasts, EIA oil inventories, well permits, well production, refining spreads) plus 4 authenticated price-alert tools (create/list/delete persistent alerts + trigger activity) and 5 agent tools (multi-commodity market briefs, persistent price watches)
 - **5 Resources** — subscribable price snapshots for Brent, WTI, Natural Gas, Diesel, and all commodities
 - **6 Prompts** — pre-built analyst templates (daily briefing, spread analysis, gas markets, commodity report, diesel costs, supply analysis)
 - **Natural language** — ask for "brent oil" or "natural gas", not codes
@@ -169,7 +169,7 @@ All tools are prefixed with `opa_` to avoid name collisions when multiple MCP se
 | `opa_get_rig_counts`      | Baker Hughes US rig count with week-over-week change                                            |
 | `opa_get_drilling`        | Drilling snapshot: rig counts, frac spreads, 30-day permits, DUCs                               |
 | `opa_get_diesel_by_state` | AAA retail diesel price for any US state (50 states + DC)                                       |
-| `opa_get_fuel_surcharge`  | Published LTL carrier fuel surcharge % (ODFL, Saia, Estes, FedEx Freight, XPO, ABF, ...) tied to the DOE diesel index |
+| `opa_get_fuel_surcharge`  | LTL and parcel carrier fuel surcharge percentages with effective dates and source provenance     |
 | `opa_get_storage`         | Cushing and SPR oil storage/inventory levels                                                    |
 | `opa_get_opec_production` | OPEC country-level production data                                                              |
 | `opa_get_forecasts`       | EIA STEO energy price forecasts                                                                 |
@@ -217,6 +217,7 @@ The market brief gives a multi-commodity snapshot in one call. Subscriptions ("w
 "What were the latest EIA crude oil inventories?"
 "How many well permits were issued in Texas?"
 "What's the current 3-2-1 crack spread?"
+"What's the UPS ground fuel surcharge?"
 "Show me the ICE Gasoil futures curve"
 ```
 
@@ -294,7 +295,7 @@ Same data, every stack:
 
 This MCP server runs locally on your machine and only communicates with the OilPriceAPI service:
 
-- **What is sent**: tool requests are translated into HTTPS calls to `api.oilpriceapi.com` (commodity codes, query parameters such as time period or state, and — for alert/subscription tools — the alert parameters you specify), authenticated with your API key. **No conversation content is transmitted** — only the structured tool inputs above.
+- **What is sent**: tool requests are translated into HTTPS calls to `api.oilpriceapi.com` (commodity codes, query parameters such as time period or state, carrier slugs and service-level inputs for fuel surcharges, and — for alert/subscription tools — the alert parameters you specify), authenticated with your API key. **No conversation content is transmitted** — only the structured tool inputs above.
 - **API key storage**: your key is stored locally in your MCP client's configuration (or the `OILPRICEAPI_KEY` environment variable). It is sent only to `api.oilpriceapi.com` as an Authorization header.
 - **Logging**: API requests are logged by OilPriceAPI as described in the [OilPriceAPI Privacy Policy](https://www.oilpriceapi.com/privacy).
 - **Third parties**: no data is shared with third parties beyond what that policy describes.

--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,9 @@
   "manifest_version": "0.2",
   "name": "oilpriceapi",
   "display_name": "OilPriceAPI — Oil, Gas & Commodity Prices",
-  "version": "2.4.2",
-  "description": "Real-time oil, gas & commodity prices. 26 tools: spot, history, futures, alerts, market briefs.",
-  "long_description": "The energy commodity MCP server. Live spot prices for Brent, WTI, natural gas, diesel, gasoline and 70+ commodities, plus historical data, futures curves, refining spreads, rig counts, OPEC production, price alerts and multi-commodity market briefs. Works instantly in demo mode (no API key) with a limited commodity set; a free API key from oilpriceapi.com unlocks everything.",
+  "version": "2.6.0",
+  "description": "Real-time oil, gas & commodity prices. 28 tools: spot, history, futures, fuel surcharges, alerts, market briefs.",
+  "long_description": "The energy commodity MCP server. Live spot prices for Brent, WTI, natural gas, diesel, gasoline and 70+ commodities, plus historical data, futures curves, refining spreads, carrier fuel surcharges, rig counts, OPEC production, price alerts and multi-commodity market briefs. Works instantly in demo mode (no API key) with a limited commodity set; a free API key from oilpriceapi.com unlocks everything.",
   "author": {
     "name": "OilPriceAPI",
     "email": "support@oilpriceapi.com",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.OilpriceAPI/mcp-server",
-  "description": "Real-time oil, gas & commodity data. 28 tools: spot, futures, drilling, wells, alerts.",
+  "description": "Real-time oil, gas & commodity data. 28 tools: spot, futures, drilling, wells, fuel surcharges, alerts.",
   "repository": {
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -23,14 +23,11 @@ import {
   createSandboxServer,
   wellProductionEndpoint,
   formatWellProduction,
+  fuelSurchargeEndpoint,
+  formatFuelSurchargeData,
   formatDrillingData,
   WELL_PRODUCTION_VIEWS,
   WELL_PRODUCTION_BETA_NOTE,
-  resolveCarrierSlug,
-  fuelSurchargeEndpoint,
-  formatFuelSurcharge,
-  FUEL_SURCHARGE_CARRIER_ALIASES,
-  FUEL_SURCHARGE_PROVENANCE_NOTE,
   CLIENT_MARKER,
   MCP_VERSION,
 } from "../index.js";
@@ -853,6 +850,7 @@ describe("keylessTeaserResult (#16)", () => {
       "opa_get_market_brief",
       "opa_create_price_subscription",
       "opa_get_subscription_events",
+      "opa_get_fuel_surcharge",
     ]) {
       const text = keylessTeaserResult(tool).content[0].text;
       expect(text).toContain(tool);
@@ -1121,6 +1119,279 @@ describe("tool registration metadata", () => {
         openWorldHint: true,
       });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #4790 — fuel surcharge tool (opa_get_fuel_surcharge)
+// ---------------------------------------------------------------------------
+
+describe("fuelSurchargeEndpoint (#4790) - request mapping", () => {
+  it("maps carrier lists to the LTL endpoint by default", () => {
+    expect(fuelSurchargeEndpoint()).toEqual({
+      endpoint: "/v1/fuel-surcharge",
+      resolvedMode: "ltl",
+    });
+  });
+
+  it("maps parcel carrier lists when mode is explicit", () => {
+    expect(fuelSurchargeEndpoint({ mode: "parcel" })).toEqual({
+      endpoint: "/v1/fuel-surcharge/parcel",
+      resolvedMode: "parcel",
+    });
+  });
+
+  it("auto-routes parcel carriers to parcel latest endpoints", () => {
+    expect(fuelSurchargeEndpoint({ carrier: "UPS" })).toEqual({
+      endpoint: "/v1/fuel-surcharge/parcel/ups/latest",
+      resolvedMode: "parcel",
+      carrier: "ups",
+    });
+  });
+
+  it("normalizes common LTL carrier names and clamps history page size", () => {
+    expect(
+      fuelSurchargeEndpoint({
+        carrier: "Old Dominion Freight Line",
+        history: true,
+        per_page: 500,
+      }),
+    ).toEqual({
+      endpoint: "/v1/fuel-surcharge/odfl/history?per_page=100",
+      resolvedMode: "ltl",
+      carrier: "odfl",
+    });
+  });
+
+  it("requires service_level for parcel history", () => {
+    const mapped = fuelSurchargeEndpoint({
+      carrier: "fedex",
+      history: true,
+    });
+
+    expect(mapped).toEqual({
+      error: expect.stringContaining("requires service_level"),
+    });
+  });
+
+  it("maps parcel service-level history with normalized service levels", () => {
+    expect(
+      fuelSurchargeEndpoint({
+        carrier: "DHL Express",
+        service_level: "International Air Export",
+        history: true,
+        per_page: 2,
+      }),
+    ).toEqual({
+      endpoint:
+        "/v1/fuel-surcharge/parcel/dhl/history?service_level=international_air_export&per_page=2",
+      resolvedMode: "parcel",
+      carrier: "dhl",
+      serviceLevel: "international_air_export",
+    });
+  });
+});
+
+describe("formatFuelSurchargeData (#4790)", () => {
+  it("renders LTL latest data with staleness and diesel-band provenance", () => {
+    const text = formatFuelSurchargeData(
+      {
+        carrier: "odfl",
+        carrier_name: "Old Dominion Freight Line",
+        mode: "ltl",
+        surcharge_percent: 38.32,
+        effective_date: "2026-07-14",
+        doe_diesel_price: 3.72,
+        diesel_band: { min: 3.7, max: 3.75 },
+        source: "carrier_schedule",
+        retrieved_at: "2026-07-14T05:00:00Z",
+      },
+      { mode: "ltl" },
+    );
+
+    expect(text).toContain("LTL Fuel Surcharge");
+    expect(text).toContain("Old Dominion Freight Line (odfl)");
+    expect(text).toContain("38.32%");
+    expect(text).toContain("effective 2026-07-14");
+    expect(text).toContain("$3.720/gal");
+    expect(text).toContain("$3.70-$3.75 DOE band");
+    expect(text).toContain("retrieved 2026-07-14T05:00:00Z");
+  });
+
+  it("renders parcel grouped latest data by service level", () => {
+    const text = formatFuelSurchargeData(
+      {
+        carrier: "ups",
+        carrier_name: "UPS",
+        mode: "parcel",
+        service_levels: [
+          {
+            service_level: "ground",
+            surcharge_percent: 25.25,
+            effective_date: "2026-07-20",
+            source: "carrier_schedule",
+          },
+          {
+            service_level: "air",
+            surcharge_percent: 21.5,
+            effective_date: "2026-07-20",
+            source: "carrier_schedule",
+          },
+        ],
+      },
+      { mode: "parcel" },
+    );
+
+    expect(text).toContain("Parcel Fuel Surcharge");
+    expect(text).toContain("UPS (ups)");
+    expect(text).toContain("**ground**: 25.25%");
+    expect(text).toContain("**air**: 21.50%");
+  });
+
+  it("renders paginated history metadata", () => {
+    const text = formatFuelSurchargeData(
+      {
+        history: [
+          {
+            carrier: "ups",
+            carrier_name: "UPS",
+            service_level: "ground",
+            surcharge_percent: 25.25,
+            effective_date: "2026-07-20",
+          },
+        ],
+        meta: { page: 1, per_page: 1, total_count: 13, total_pages: 13 },
+      },
+      { mode: "parcel", history: true },
+    );
+
+    expect(text).toContain("Parcel Fuel Surcharge History - UPS (ups)");
+    expect(text).toContain("showing 1 of 13 rows");
+  });
+});
+
+describe("opa_get_fuel_surcharge (#4790) - tool handler", () => {
+  const server = createSandboxServer();
+  const tools = (
+    server as unknown as {
+      _registeredTools: Record<
+        string,
+        {
+          handler: (
+            args: Record<string, unknown>,
+            extra: Record<string, unknown>,
+          ) => Promise<{
+            content: Array<{ type: string; text: string }>;
+            isError?: boolean;
+          }>;
+        }
+      >;
+    }
+  )._registeredTools;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the keyless teaser when no API key is configured", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "");
+    vi.stubEnv("OIL_PRICE_API_KEY", "");
+
+    const result = await tools.opa_get_fuel_surcharge.handler(
+      { carrier: "ups" },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("opa_get_fuel_surcharge");
+    expect(result.content[0].text).toContain("fuel surcharge percentages");
+    expect(result.content[0].text).toContain(SIGNUP_URL);
+  });
+
+  it("calls the LTL latest endpoint and formats the payload", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({
+        status: "success",
+        data: {
+          carrier: "odfl",
+          carrier_name: "Old Dominion Freight Line",
+          mode: "ltl",
+          surcharge_percent: 38.32,
+          effective_date: "2026-07-14",
+          source: "carrier_schedule",
+          retrieved_at: "2026-07-14T05:00:00Z",
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await tools.opa_get_fuel_surcharge.handler(
+      { carrier: "ODFL" },
+      {},
+    );
+
+    expect(fetchSpy.mock.calls[0][0]).toContain(
+      "/v1/fuel-surcharge/odfl/latest",
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("38.32%");
+    expect(result.content[0].text).toContain("Old Dominion Freight Line");
+  });
+
+  it("auto-routes UPS to parcel latest and renders service levels", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({
+        status: "success",
+        data: {
+          carrier: "ups",
+          carrier_name: "UPS",
+          mode: "parcel",
+          service_levels: [
+            {
+              service_level: "ground",
+              surcharge_percent: 25.25,
+              effective_date: "2026-07-20",
+            },
+          ],
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await tools.opa_get_fuel_surcharge.handler(
+      { carrier: "UPS" },
+      {},
+    );
+
+    expect(fetchSpy.mock.calls[0][0]).toContain(
+      "/v1/fuel-surcharge/parcel/ups/latest",
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("**ground**: 25.25%");
+  });
+
+  it("rejects parcel history without service_level before calling the API", async () => {
+    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await tools.opa_get_fuel_surcharge.handler(
+      { carrier: "UPS", history: true },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("requires service_level");
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -1542,293 +1813,6 @@ describe("keylessTeaserResult covers opa_get_well_production (#31)", () => {
     const text = keylessTeaserResult("opa_get_well_production").content[0].text;
     expect(text).toContain("opa_get_well_production");
     expect(text).toContain("beta coverage");
-    expect(text).toContain(SIGNUP_URL);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// #43 — LTL carrier fuel surcharge (opa_get_fuel_surcharge)
-// ---------------------------------------------------------------------------
-
-describe("resolveCarrierSlug (#43)", () => {
-  it("maps common carrier names and abbreviations to slugs", () => {
-    expect(resolveCarrierSlug("ODFL")).toBe("odfl");
-    expect(resolveCarrierSlug("Old Dominion")).toBe("odfl");
-    expect(resolveCarrierSlug("old dominion freight line")).toBe("odfl");
-    expect(resolveCarrierSlug("Saia")).toBe("saia");
-    expect(resolveCarrierSlug("Estes Express")).toBe("estes");
-    expect(resolveCarrierSlug("FedEx Freight")).toBe("fedex-freight");
-    expect(resolveCarrierSlug("fedex")).toBe("fedex-freight");
-    expect(resolveCarrierSlug("XPO")).toBe("xpo");
-    expect(resolveCarrierSlug("ArcBest")).toBe("abf");
-    expect(resolveCarrierSlug("R+L Carriers")).toBe("rl-carriers");
-    expect(resolveCarrierSlug("TForce Freight")).toBe("tforce");
-    expect(resolveCarrierSlug("SEFL")).toBe("southeastern");
-  });
-
-  it("slugifies unknown carriers instead of rejecting them", () => {
-    expect(resolveCarrierSlug("Dayton Freight")).toBe("dayton-freight");
-    expect(resolveCarrierSlug("  A. Duie Pyle  ")).toBe("a-duie-pyle");
-  });
-
-  it("every alias value is already a canonical slug (aliases don't chain)", () => {
-    for (const slug of Object.values(FUEL_SURCHARGE_CARRIER_ALIASES)) {
-      expect(resolveCarrierSlug(slug)).toBe(slug);
-    }
-  });
-});
-
-describe("fuelSurchargeEndpoint (#43) - request mapping", () => {
-  it("maps no carrier to the all-carriers list endpoint", () => {
-    expect(fuelSurchargeEndpoint()).toBe("/v1/fuel-surcharge");
-    expect(fuelSurchargeEndpoint(undefined)).toBe("/v1/fuel-surcharge");
-    expect(fuelSurchargeEndpoint("   ")).toBe("/v1/fuel-surcharge");
-  });
-
-  it("maps a carrier to its /latest endpoint via the slug resolver", () => {
-    expect(fuelSurchargeEndpoint("ODFL")).toBe(
-      "/v1/fuel-surcharge/odfl/latest",
-    );
-    expect(fuelSurchargeEndpoint("FedEx Freight")).toBe(
-      "/v1/fuel-surcharge/fedex-freight/latest",
-    );
-  });
-});
-
-// Contract fixture from oilpriceapi-api#4772 (shared API contract).
-const FUEL_SURCHARGE_CONTRACT_ENTRY = {
-  carrier: "odfl",
-  carrier_name: "Old Dominion Freight Line",
-  mode: "ltl",
-  surcharge_percent: 33.9,
-  effective_date: "2026-07-13",
-  doe_diesel_price: 3.756,
-  diesel_band: { min: 3.7, max: 3.79 },
-  source: "https://www.odfl.com/us/en/resources/fuel-surcharge.html",
-  retrieved_at: "2026-07-15T12:00:00Z",
-};
-
-describe("formatFuelSurcharge (#43) - formatting", () => {
-  it("formats the all-carriers list payload from the #4772 contract", () => {
-    const text = formatFuelSurcharge({
-      carriers: [FUEL_SURCHARGE_CONTRACT_ENTRY],
-    });
-
-    expect(text).toContain("LTL Carrier Fuel Surcharges (1 carriers)");
-    expect(text).toContain("Old Dominion Freight Line");
-    expect(text).toContain("`odfl`");
-    expect(text).toContain("33.9%");
-    expect(text).toContain("effective 2026-07-13");
-    expect(text).toContain("$3.70–$3.79/gal");
-    expect(text).toContain("DOE diesel: $3.756/gal");
-    expect(text).toContain(
-      "https://www.odfl.com/us/en/resources/fuel-surcharge.html",
-    );
-    expect(text).toContain("retrieved 2026-07-15T12:00:00Z");
-    expect(text).toContain(FUEL_SURCHARGE_PROVENANCE_NOTE);
-  });
-
-  it("formats a single-carrier /latest payload (same shape, no carriers[])", () => {
-    const text = formatFuelSurcharge(FUEL_SURCHARGE_CONTRACT_ENTRY);
-
-    expect(text).toContain("# Fuel Surcharge — Old Dominion Freight Line");
-    expect(text).toContain("33.9%");
-    expect(text).toContain(FUEL_SURCHARGE_PROVENANCE_NOTE);
-  });
-
-  it("tolerates missing optional fields without throwing or fabricating", () => {
-    const text = formatFuelSurcharge({
-      carriers: [{ carrier: "saia" }],
-    });
-
-    expect(text).toContain("saia");
-    expect(text).toContain("(surcharge not reported)");
-    expect(text).not.toContain("NaN");
-    expect(text).not.toContain("undefined");
-    expect(text).toContain(FUEL_SURCHARGE_PROVENANCE_NOTE);
-  });
-
-  it("keeps serving stale values with their TRUE retrieved_at (honest staleness)", () => {
-    // The contract mandates: stale carrier fetch => last value with its real
-    // effective_date/retrieved_at, never faked freshness. The formatter must
-    // surface whatever timestamps the API reports, unmodified.
-    const stale = {
-      ...FUEL_SURCHARGE_CONTRACT_ENTRY,
-      effective_date: "2026-05-04",
-      retrieved_at: "2026-05-06T12:00:00Z",
-    };
-    const text = formatFuelSurcharge({ carriers: [stale] });
-    expect(text).toContain("effective 2026-05-04");
-    expect(text).toContain("retrieved 2026-05-06T12:00:00Z");
-  });
-});
-
-describe("opa_get_fuel_surcharge (#43) - tool handler paths", () => {
-  const server = createSandboxServer();
-  const tools = (
-    server as unknown as {
-      _registeredTools: Record<
-        string,
-        {
-          handler: (
-            args: Record<string, unknown>,
-            extra: Record<string, unknown>,
-          ) => Promise<{
-            content: Array<{ type: string; text: string }>;
-            isError?: boolean;
-          }>;
-        }
-      >;
-    }
-  )._registeredTools;
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.unstubAllGlobals();
-  });
-
-  it("returns the keyless teaser when no API key is configured", async () => {
-    vi.stubEnv("OILPRICEAPI_KEY", "");
-    vi.stubEnv("OIL_PRICE_API_KEY", "");
-
-    const result = await tools.opa_get_fuel_surcharge.handler({}, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("opa_get_fuel_surcharge");
-    expect(result.content[0].text).toContain(SIGNUP_URL);
-    expect(result.content[0].text).not.toContain("Authentication failed");
-  });
-
-  it("keyed all-carriers call formats the contract shape end-to-end", async () => {
-    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
-    const fetchSpy = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      headers: { get: () => null },
-      json: async () => ({
-        status: "success",
-        data: { carriers: [FUEL_SURCHARGE_CONTRACT_ENTRY] },
-      }),
-    });
-    vi.stubGlobal("fetch", fetchSpy);
-
-    const result = await tools.opa_get_fuel_surcharge.handler({}, {});
-
-    expect(result.isError).toBeUndefined();
-    expect(result.content[0].text).toContain("Old Dominion Freight Line");
-    expect(result.content[0].text).toContain("33.9%");
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(String(fetchSpy.mock.calls[0][0])).toContain("/v1/fuel-surcharge");
-  });
-
-  it("keyed single-carrier call hits the /{carrier}/latest endpoint", async () => {
-    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
-    const fetchSpy = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      headers: { get: () => null },
-      json: async () => ({
-        status: "success",
-        data: FUEL_SURCHARGE_CONTRACT_ENTRY,
-      }),
-    });
-    vi.stubGlobal("fetch", fetchSpy);
-
-    const result = await tools.opa_get_fuel_surcharge.handler(
-      { carrier: "Old Dominion" },
-      {},
-    );
-
-    expect(result.isError).toBeUndefined();
-    expect(result.content[0].text).toContain(
-      "# Fuel Surcharge — Old Dominion Freight Line",
-    );
-    expect(String(fetchSpy.mock.calls[0][0])).toContain(
-      "/v1/fuel-surcharge/odfl/latest",
-    );
-  });
-
-  it("returns a clear 'not yet available' error when the endpoint 404s (not yet deployed) — never a crash, never fabricated data", async () => {
-    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 404,
-        statusText: "Not Found",
-        headers: { get: () => null },
-        text: async () => JSON.stringify({ error: "Not found" }),
-      }),
-    );
-
-    const result = await tools.opa_get_fuel_surcharge.handler({}, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain(
-      "Fuel surcharge data is not yet available",
-    );
-    // Never fabricate a surcharge value on the unavailable path.
-    expect(result.content[0].text).not.toMatch(/\d+\.\d+%/);
-  });
-
-  it("returns a carrier-aware error on 404 for a specific carrier", async () => {
-    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 404,
-        statusText: "Not Found",
-        headers: { get: () => null },
-        text: async () =>
-          JSON.stringify({ error: "Unknown carrier: dayton-freight" }),
-      }),
-    );
-
-    const result = await tools.opa_get_fuel_surcharge.handler(
-      { carrier: "Dayton Freight" },
-      {},
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Dayton Freight");
-    expect(result.content[0].text).toContain("without a carrier");
-  });
-
-  it("surfaces the 402 entitlement gate with the upgrade link", async () => {
-    vi.stubEnv("OILPRICEAPI_KEY", "test-key-123");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 402,
-        statusText: "Payment Required",
-        headers: { get: () => null },
-        text: async () =>
-          JSON.stringify({
-            message: "Fuel surcharge data requires a paid plan",
-          }),
-      }),
-    );
-
-    // Calling the handler directly bypasses the SDK's error-to-result
-    // conversion, so the ApiGateError surfaces as a rejection here.
-    await expect(
-      tools.opa_get_fuel_surcharge.handler({}, {}),
-    ).rejects.toMatchObject({
-      name: "ApiGateError",
-      status: 402,
-      message: expect.stringContaining(UPGRADE_URL),
-    });
-  });
-});
-
-describe("keylessTeaserResult covers opa_get_fuel_surcharge (#43)", () => {
-  it("returns the fuel-surcharge teaser with LTL + DOE wording", () => {
-    const text = keylessTeaserResult("opa_get_fuel_surcharge").content[0].text;
-    expect(text).toContain("opa_get_fuel_surcharge");
-    expect(text).toContain("LTL");
-    expect(text).toContain("DOE");
     expect(text).toContain(SIGNUP_URL);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@
  * 28 tools total (opa_ prefixed):
  *
  * 19 read-only tools: prices, history, futures, marine fuels, rig counts,
- * drilling, diesel-by-state, LTL carrier fuel surcharges, storage, OPEC
+ * drilling, diesel-by-state, LTL and parcel fuel surcharges, storage, OPEC
  * production, forecasts, EIA oil inventories, well permits, well production,
  * refining spreads.
  *
@@ -486,13 +486,342 @@ interface DrillingData {
   last_updated?: string;
 }
 
+export const FUEL_SURCHARGE_MODES = ["auto", "ltl", "parcel"] as const;
+export type FuelSurchargeMode = (typeof FUEL_SURCHARGE_MODES)[number];
+type ResolvedFuelSurchargeMode = Exclude<FuelSurchargeMode, "auto">;
+
+const PARCEL_FUEL_SURCHARGE_SLUGS = new Set(["ups", "fedex", "dhl"]);
+
+export const FUEL_SURCHARGE_CARRIER_ALIASES: Record<string, string> = {
+  odfl: "odfl",
+  "old dominion": "odfl",
+  "old dominion freight": "odfl",
+  "old dominion freight line": "odfl",
+  od: "odfl",
+  saia: "saia",
+  "saia ltl freight": "saia",
+  estes: "estes",
+  "estes express": "estes",
+  "estes express lines": "estes",
+  sefl: "southeastern-freight",
+  southeastern: "southeastern-freight",
+  "southeastern freight": "southeastern-freight",
+  "southeastern freight lines": "southeastern-freight",
+  "fedex freight": "fedex-freight",
+  "federal express freight": "fedex-freight",
+  "r+l": "rl-carriers",
+  "r+l carriers": "rl-carriers",
+  rl: "rl-carriers",
+  "rl carriers": "rl-carriers",
+  "abf freight": "abf",
+  arcbest: "abf",
+  "t force": "tforce",
+  "t-force": "tforce",
+  "tforce freight": "tforce",
+  "xpo logistics": "xpo",
+  "averitt express": "averitt",
+  "dhl express": "dhl",
+  "fed ex": "fedex",
+  "federal express": "fedex",
+};
+
+interface FuelSurchargeEndpointOptions {
+  carrier?: string;
+  mode?: FuelSurchargeMode;
+  service_level?: string;
+  history?: boolean;
+  per_page?: number;
+}
+
+interface FuelSurchargeEndpointResult {
+  endpoint: string;
+  resolvedMode: ResolvedFuelSurchargeMode;
+  carrier?: string;
+  serviceLevel?: string;
+}
+
+interface FuelSurchargeRate {
+  carrier?: string;
+  carrier_name?: string;
+  mode?: string;
+  service_level?: string;
+  surcharge_percent?: number | string | null;
+  effective_date?: string;
+  doe_diesel_price?: number | string | null;
+  diesel_band?: {
+    min?: number | string | null;
+    max?: number | string | null;
+  } | null;
+  source?: string;
+  retrieved_at?: string;
+}
+
+interface FuelSurchargeCarrier extends FuelSurchargeRate {
+  service_levels?: FuelSurchargeRate[];
+}
+
+interface FuelSurchargeData extends FuelSurchargeCarrier {
+  carriers?: FuelSurchargeCarrier[];
+  history?: FuelSurchargeRate[];
+  meta?: {
+    page?: number;
+    per_page?: number;
+    total_count?: number;
+    total_pages?: number;
+    [key: string]: unknown;
+  };
+}
+
+function normalizeFuelSurchargeSlug(input?: string): string | undefined {
+  const normalized = input?.trim().toLowerCase();
+  if (!normalized) return undefined;
+
+  const alias = FUEL_SURCHARGE_CARRIER_ALIASES[normalized];
+  if (alias) return alias;
+
+  return normalized
+    .replace(/[^a-z0-9_\s-]/g, "")
+    .replace(/[_\s]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export function resolveCarrierSlug(input: string): string {
+  return normalizeFuelSurchargeSlug(input) ?? "";
+}
+
+function normalizeFuelSurchargeServiceLevel(input?: string): string | undefined {
+  const normalized = input?.trim().toLowerCase();
+  if (!normalized) return undefined;
+
+  return normalized
+    .replace(/[^a-z0-9_\s-]/g, "")
+    .replace(/[\s-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+}
+
+function boundedFuelSurchargePerPage(perPage?: number): number {
+  if (!Number.isFinite(perPage)) return 12;
+  return Math.min(Math.max(Math.trunc(perPage as number), 1), 100);
+}
+
+/**
+ * Map MCP fuel-surcharge args to the public API contract (#4790).
+ * Auto mode treats UPS/FedEx/DHL as parcel carriers and all other slugs as LTL.
+ */
+export function fuelSurchargeEndpoint(
+  opts: FuelSurchargeEndpointOptions = {},
+): FuelSurchargeEndpointResult | { error: string } {
+  const requestedMode = opts.mode ?? "auto";
+  const carrier = normalizeFuelSurchargeSlug(opts.carrier);
+
+  if (!carrier) {
+    return requestedMode === "parcel"
+      ? { endpoint: "/v1/fuel-surcharge/parcel", resolvedMode: "parcel" }
+      : { endpoint: "/v1/fuel-surcharge", resolvedMode: "ltl" };
+  }
+
+  const resolvedMode: ResolvedFuelSurchargeMode =
+    requestedMode === "auto"
+      ? PARCEL_FUEL_SURCHARGE_SLUGS.has(carrier)
+        ? "parcel"
+        : "ltl"
+      : requestedMode;
+
+  const perPage = boundedFuelSurchargePerPage(opts.per_page);
+
+  if (resolvedMode === "parcel") {
+    const serviceLevel = normalizeFuelSurchargeServiceLevel(opts.service_level);
+    const base = `/v1/fuel-surcharge/parcel/${encodeURIComponent(carrier)}`;
+
+    if (opts.history) {
+      if (!serviceLevel) {
+        return {
+          error:
+            "Parcel fuel-surcharge history requires service_level (for example: ground, air, international_air_export). Call latest without service_level to list available service levels.",
+        };
+      }
+
+      const params = new URLSearchParams({
+        service_level: serviceLevel,
+        per_page: String(perPage),
+      });
+      return {
+        endpoint: `${base}/history?${params.toString()}`,
+        resolvedMode,
+        carrier,
+        serviceLevel,
+      };
+    }
+
+    if (serviceLevel) {
+      const params = new URLSearchParams({ service_level: serviceLevel });
+      return {
+        endpoint: `${base}/latest?${params.toString()}`,
+        resolvedMode,
+        carrier,
+        serviceLevel,
+      };
+    }
+
+    return { endpoint: `${base}/latest`, resolvedMode, carrier };
+  }
+
+  const base = `/v1/fuel-surcharge/${encodeURIComponent(carrier)}`;
+  return opts.history
+    ? {
+        endpoint: `${base}/history?per_page=${perPage}`,
+        resolvedMode,
+        carrier,
+      }
+    : { endpoint: `${base}/latest`, resolvedMode, carrier };
+}
+
+function fuelSurchargeCarrierLabel(rate: FuelSurchargeRate): string {
+  if (rate.carrier_name && rate.carrier) {
+    return `${rate.carrier_name} (${rate.carrier})`;
+  }
+  return rate.carrier_name || rate.carrier || "Carrier";
+}
+
+function fuelSurchargeNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function formatFuelSurchargePercent(value: unknown): string {
+  const percent = fuelSurchargeNumber(value);
+  return percent === null ? "n/a" : `${percent.toFixed(2)}%`;
+}
+
+function formatFuelSurchargeMoney(value: unknown): string | null {
+  const amount = fuelSurchargeNumber(value);
+  return amount === null ? null : `$${amount.toFixed(3)}/gal`;
+}
+
+function formatFuelSurchargeBand(
+  band: FuelSurchargeRate["diesel_band"],
+): string | null {
+  if (!band) return null;
+
+  const min = fuelSurchargeNumber(band.min);
+  const max = fuelSurchargeNumber(band.max);
+  if (min === null && max === null) return null;
+  if (min !== null && max !== null) return `$${min.toFixed(2)}-$${max.toFixed(2)} DOE band`;
+  if (min !== null) return `$${min.toFixed(2)}+ DOE band`;
+  return `up to $${max!.toFixed(2)} DOE band`;
+}
+
+function formatFuelSurchargeLine(rate: FuelSurchargeRate): string {
+  const label = rate.service_level
+    ? `${rate.service_level}`
+    : fuelSurchargeCarrierLabel(rate);
+  const parts = [`**${label}**: ${formatFuelSurchargePercent(rate.surcharge_percent)}`];
+
+  if (rate.effective_date) parts.push(`effective ${rate.effective_date}`);
+
+  const dieselPrice = formatFuelSurchargeMoney(rate.doe_diesel_price);
+  if (dieselPrice) parts.push(`DOE diesel ${dieselPrice}`);
+
+  const band = formatFuelSurchargeBand(rate.diesel_band);
+  if (band) parts.push(band);
+
+  if (rate.source) parts.push(`source ${rate.source}`);
+  if (rate.retrieved_at) parts.push(`retrieved ${rate.retrieved_at}`);
+
+  return `- ${parts.join(" · ")}`;
+}
+
+function formatFuelSurchargeCarrier(carrier: FuelSurchargeCarrier): string {
+  if (carrier.service_levels?.length) {
+    const lines = [`## ${fuelSurchargeCarrierLabel(carrier)}`];
+    for (const rate of carrier.service_levels) {
+      lines.push(
+        formatFuelSurchargeLine({
+          ...rate,
+          carrier: rate.carrier ?? carrier.carrier,
+          carrier_name: rate.carrier_name ?? carrier.carrier_name,
+          mode: rate.mode ?? carrier.mode,
+        }),
+      );
+    }
+    return lines.join("\n");
+  }
+
+  return formatFuelSurchargeLine(carrier);
+}
+
+/**
+ * Format fuel-surcharge API payloads for agent-readable output.
+ * The output preserves effective/retrieved dates and source so staleness is
+ * visible instead of implying the carrier schedule was updated today.
+ */
+export function formatFuelSurchargeData(
+  data: FuelSurchargeData,
+  opts: { mode?: ResolvedFuelSurchargeMode; history?: boolean } = {},
+): string {
+  const modeLabel = opts.mode === "parcel" ? "Parcel" : "LTL";
+
+  if (data.carriers?.length) {
+    const sections = [`# ${modeLabel} Fuel Surcharges\n`];
+    for (const carrier of data.carriers) {
+      sections.push(formatFuelSurchargeCarrier(carrier), "");
+    }
+    sections.push("_Data from [OilPriceAPI](https://oilpriceapi.com)_");
+    return sections.join("\n");
+  }
+
+  if (data.history?.length) {
+    const first = data.history[0];
+    const sections = [
+      `# ${modeLabel} Fuel Surcharge History - ${fuelSurchargeCarrierLabel(first)}\n`,
+    ];
+    for (const rate of data.history) {
+      sections.push(formatFuelSurchargeLine(rate));
+    }
+    if (data.meta) {
+      const total =
+        typeof data.meta.total_count === "number"
+          ? ` of ${data.meta.total_count}`
+          : "";
+      sections.push(
+        "",
+        `_Page ${data.meta.page ?? 1}${data.meta.total_pages ? ` of ${data.meta.total_pages}` : ""}; showing ${data.history.length}${total} rows._`,
+      );
+    }
+    sections.push("", "_Data from [OilPriceAPI](https://oilpriceapi.com)_");
+    return sections.join("\n");
+  }
+
+  if (data.service_levels?.length) {
+    return [
+      `# ${modeLabel} Fuel Surcharge - ${fuelSurchargeCarrierLabel(data)}\n`,
+      formatFuelSurchargeCarrier(data),
+      "",
+      "_Data from [OilPriceAPI](https://oilpriceapi.com)_",
+    ].join("\n");
+  }
+
+  return [
+    `# ${modeLabel} Fuel Surcharge - ${fuelSurchargeCarrierLabel(data)}\n`,
+    formatFuelSurchargeLine(data),
+    "",
+    "_Data from [OilPriceAPI](https://oilpriceapi.com)_",
+  ].join("\n");
+}
+
 // ---------------------------------------------------------------------------
 // Create server instance
 // ---------------------------------------------------------------------------
 
 const server = new McpServer({
   name: "oilpriceapi",
-  version: "2.6.0",
+  version: MCP_VERSION,
 });
 
 // ---------------------------------------------------------------------------
@@ -1322,11 +1651,6 @@ const KEYLESS_TOOL_TEASERS: Record<string, { does: string; example: string }> =
       does: "Returns the AAA average retail diesel price for any US state.",
       example: "Diesel Price — TX: $X.XXX/gallon (24h change ±$0.0XX)",
     },
-    opa_get_fuel_surcharge: {
-      does: "Returns the fuel surcharge percentage each major LTL freight carrier (ODFL, Saia, Estes, FedEx Freight, XPO, ABF, ...) currently publishes, with the effective date, the matched DOE/EIA on-highway diesel price band, the underlying DOE diesel price, and source + retrieval provenance.",
-      example:
-        "Old Dominion Freight Line (odfl): XX.X% — effective YYYY-MM-DD · diesel band $X.XX–$X.XX · DOE diesel $X.XXX/gal",
-    },
     opa_get_storage: {
       does: "Returns oil storage/inventory levels for Cushing, Oklahoma and the US Strategic Petroleum Reserve.",
       example:
@@ -1360,6 +1684,11 @@ const KEYLESS_TOOL_TEASERS: Record<string, { does: string; example: string }> =
     opa_get_spread: {
       does: "Returns refining and trading spreads: crack spreads, basis differentials, and blending/transport margins.",
       example: "3-2-1 crack spread: $XX.XX/bbl (as of YYYY-MM-DD)",
+    },
+    opa_get_fuel_surcharge: {
+      does: "Returns carrier-published LTL and parcel fuel surcharge percentages with effective dates, retrieval timestamps, diesel bands where applicable, and source provenance.",
+      example:
+        "UPS ground fuel surcharge: XX.XX% · effective YYYY-MM-DD · source carrier_schedule · retrieved YYYY-MM-DDTHH:MM:SSZ",
     },
     opa_create_price_alert: {
       does: "Creates a persistent price alert on your account that emails (and optionally webhooks) you when a commodity crosses a threshold.",
@@ -1431,7 +1760,7 @@ export function keylessTeaserResult(toolName: string) {
 }
 
 // =========================================================================
-// READ TOOLS (19 — opa_ prefixed to avoid collisions). Plus 4 authenticated
+// READ TOOLS (19 - opa_ prefixed to avoid collisions). Plus 4 authenticated
 // price-alert tools further below, for 23 tools total.
 // =========================================================================
 
@@ -2196,186 +2525,78 @@ server.registerTool(
   },
 );
 
-// ---------------------------------------------------------------------------
-// LTL carrier fuel surcharge (#43) — /v1/fuel-surcharge*
-//
-// Each major LTL freight carrier publishes a weekly fuel-surcharge % tied to
-// the DOE/EIA on-highway diesel index. These tools surface the carrier's own
-// PUBLISHED schedule value — not a computed estimate — with source +
-// retrieved_at provenance (collect freely, claim nothing: we track what the
-// carrier publishes and cite where/when we got it).
-//
-// NOTE: the /v1/fuel-surcharge endpoints ship in a parallel API sprint
-// (oilpriceapi-api#4767/#4772). Until they deploy, the API answers 404 and
-// this tool returns a clear "not yet available" message — never a crash,
-// never fabricated data.
-// ---------------------------------------------------------------------------
-
-/**
- * Common LTL carrier names/abbreviations → API carrier slug. Anything not in
- * the map is slugified (lowercased, non-alphanumerics → hyphens) and passed
- * through; an unknown slug gets a clean not-covered error from the API (404),
- * which the tool turns into an actionable message.
- */
-export const FUEL_SURCHARGE_CARRIER_ALIASES: Record<string, string> = {
-  odfl: "odfl",
-  "old dominion": "odfl",
-  "old dominion freight": "odfl",
-  "old dominion freight line": "odfl",
-  saia: "saia",
-  "saia ltl freight": "saia",
-  estes: "estes",
-  "estes express": "estes",
-  "estes express lines": "estes",
-  fedex: "fedex-freight",
-  "fedex freight": "fedex-freight",
-  xpo: "xpo",
-  "xpo logistics": "xpo",
-  abf: "abf",
-  "abf freight": "abf",
-  arcbest: "abf",
-  "r+l": "rl-carriers",
-  "r+l carriers": "rl-carriers",
-  rl: "rl-carriers",
-  "rl carriers": "rl-carriers",
-  averitt: "averitt",
-  "averitt express": "averitt",
-  tforce: "tforce",
-  "tforce freight": "tforce",
-  "t-force": "tforce",
-  southeastern: "southeastern",
-  "southeastern freight": "southeastern",
-  "southeastern freight lines": "southeastern",
-  sefl: "southeastern",
-};
-
-/**
- * Resolve a carrier name/abbreviation to the API carrier slug (#43).
- * Exported for tests.
- */
-export function resolveCarrierSlug(input: string): string {
-  const normalized = input.toLowerCase().trim();
-  const alias = FUEL_SURCHARGE_CARRIER_ALIASES[normalized];
-  if (alias) return alias;
-  // Slugify pass-through: "FedEx Freight" -> "fedex-freight".
-  return normalized.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
-}
-
-/**
- * Map an optional carrier to the fuel-surcharge endpoint (#43).
- * Exported for tests.
- */
-export function fuelSurchargeEndpoint(carrier?: string): string {
-  const slug = carrier?.trim() ? resolveCarrierSlug(carrier) : "";
-  return slug ? `/v1/fuel-surcharge/${slug}/latest` : "/v1/fuel-surcharge";
-}
-
-interface FuelSurchargeEntry {
-  carrier?: string;
-  carrier_name?: string;
-  mode?: string;
-  surcharge_percent?: number | null;
-  effective_date?: string;
-  doe_diesel_price?: number | null;
-  diesel_band?: { min?: number | null; max?: number | null } | null;
-  source?: string;
-  retrieved_at?: string;
-}
-
-interface FuelSurchargeListData {
-  carriers?: FuelSurchargeEntry[];
-}
-
-export const FUEL_SURCHARGE_PROVENANCE_NOTE =
-  "_Each percentage is the fuel surcharge the carrier itself publishes (matched to the DOE/EIA on-highway diesel index) — tracked from the carrier's public schedule with source + retrieval time, not a computed estimate. Data from [OilPriceAPI](https://oilpriceapi.com)_";
-
-function formatFuelSurchargeEntry(e: FuelSurchargeEntry): string {
-  const name = e.carrier_name || e.carrier || "Unknown carrier";
-  const slugPart = e.carrier
-    ? ` (\`${e.carrier}\`${e.mode ? `, ${e.mode.toUpperCase()}` : ""})`
-    : "";
-  let text = `- **${name}**${slugPart}: `;
-  text +=
-    typeof e.surcharge_percent === "number"
-      ? `**${e.surcharge_percent.toFixed(1)}%**`
-      : "(surcharge not reported)";
-  if (e.effective_date) text += ` — effective ${e.effective_date}`;
-  const details: string[] = [];
-  const band = e.diesel_band;
-  if (band && (typeof band.min === "number" || typeof band.max === "number")) {
-    const min = typeof band.min === "number" ? `$${band.min.toFixed(2)}` : "?";
-    const max = typeof band.max === "number" ? `$${band.max.toFixed(2)}` : "?";
-    details.push(`Diesel band: ${min}–${max}/gal`);
-  }
-  if (typeof e.doe_diesel_price === "number") {
-    details.push(`DOE diesel: $${e.doe_diesel_price.toFixed(3)}/gal`);
-  }
-  if (e.source) {
-    details.push(
-      `Source: ${e.source}${e.retrieved_at ? ` (retrieved ${e.retrieved_at})` : ""}`,
-    );
-  } else if (e.retrieved_at) {
-    details.push(`Retrieved: ${e.retrieved_at}`);
-  }
-  for (const d of details) text += `\n  - ${d}`;
-  return text;
-}
-
-/**
- * Format a fuel-surcharge API payload (#43): either the all-carriers list
- * ({ carriers: [...] }) or a single-carrier object (same entry shape).
- * Always ends with the provenance note. Exported for tests.
- */
-export function formatFuelSurcharge(data: Record<string, unknown>): string {
-  const list = data as FuelSurchargeListData;
-  let text: string;
-  if (Array.isArray(list.carriers)) {
-    text = `# LTL Carrier Fuel Surcharges (${list.carriers.length} carriers)\n\n`;
-    text += list.carriers.map(formatFuelSurchargeEntry).join("\n");
-  } else {
-    const entry = data as FuelSurchargeEntry;
-    text = `# Fuel Surcharge — ${entry.carrier_name || entry.carrier || "Carrier"}\n\n`;
-    text += formatFuelSurchargeEntry(entry);
-  }
-  text += `\n\n${FUEL_SURCHARGE_PROVENANCE_NOTE}`;
-  return text;
-}
-
 server.registerTool(
   "opa_get_fuel_surcharge",
   {
-    title: "Get LTL Carrier Fuel Surcharge",
+    title: "Get Fuel Surcharge",
     description:
-      "Get the current published fuel surcharge percentage for major LTL freight carriers — ODFL (Old Dominion), Saia, Estes, FedEx Freight, XPO, ABF/ArcBest, R+L Carriers, Averitt, TForce Freight, Southeastern Freight Lines. Each carrier publishes a weekly fuel surcharge % tied to the DOE/EIA on-highway diesel index; this returns the carrier's own published value (not an estimate) with effective date, the matched diesel price band, the underlying DOE diesel price, and source + retrieved_at provenance. Use when the user asks about fuel surcharges, LTL freight fuel costs, carrier surcharge schedules, freight quoting/auditing, TMS or logistics rate calculations, or shipping cost pass-throughs. Omit 'carrier' to list all covered carriers with their latest %; pass a carrier name or code for one carrier. For the raw DOE diesel price itself use opa_get_price ('diesel') or opa_get_diesel_by_state.",
+      "Get carrier-published fuel surcharge percentages for LTL freight and parcel carriers. Use when the user asks about current or historical fuel surcharge rates for carriers like ODFL, Saia, Estes, XPO, ABF, TForce, Averitt, Southeastern Freight, UPS, FedEx, or DHL. Auto mode treats UPS/FedEx/DHL as parcel carriers and other carrier slugs as LTL. Parcel history requires a service_level such as ground, air, or international_air_export.",
     inputSchema: {
       carrier: z
         .string()
         .optional()
         .describe(
-          "Optional carrier name or code (e.g., 'ODFL', 'Old Dominion', 'Saia', 'Estes', 'FedEx Freight', 'XPO', 'ABF', 'R+L', 'Averitt', 'TForce', 'Southeastern'). Omit to list all covered carriers.",
+          "Optional carrier slug or common name. Examples: odfl, saia, estes, xpo, abf, tforce, averitt, southeastern-freight, ups, fedex, dhl. Omit to list current carriers.",
         ),
+      mode: z
+        .enum(FUEL_SURCHARGE_MODES)
+        .default("auto")
+        .describe(
+          "Carrier mode: auto (UPS/FedEx/DHL route to parcel; others route to LTL), ltl, or parcel. Default: auto.",
+        ),
+      service_level: z
+        .string()
+        .optional()
+        .describe(
+          "Parcel service level such as ground, air, international_air_export, international_air_import, or international_ground. Optional for latest; required for parcel history.",
+        ),
+      history: z
+        .boolean()
+        .default(false)
+        .describe(
+          "When true, return historical surcharge rows instead of the latest rate. Parcel history requires service_level.",
+        ),
+      per_page: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(12)
+        .describe("History rows to return, from 1 to 100. Default: 12."),
     },
     annotations: READ_TOOL_ANNOTATIONS,
   },
-  async ({ carrier }) => {
+  async ({ carrier, mode, service_level, history, per_page }) => {
     if (!getApiKey()) return keylessTeaserResult("opa_get_fuel_surcharge");
 
-    const endpoint = fuelSurchargeEndpoint(carrier);
-    const response =
-      await makeApiRequest<ApiResponse<Record<string, unknown>>>(endpoint);
+    const mapped = fuelSurchargeEndpoint({
+      carrier,
+      mode,
+      service_level,
+      history,
+      per_page,
+    });
+    if ("error" in mapped) return errorResult(mapped.error);
+
+    const response = await makeApiRequest<ApiResponse<FuelSurchargeData>>(
+      mapped.endpoint,
+    );
 
     if (!response || response.status !== "success") {
-      if (carrier?.trim()) {
-        return errorResult(
-          `No fuel surcharge data available for '${carrier}'. Either this carrier is not covered yet, or the fuel-surcharge dataset is not yet available. Call opa_get_fuel_surcharge without a carrier to list covered carriers. Covered-at-launch targets include ODFL, Saia, Estes, FedEx Freight, XPO, and ABF.`,
-        );
-      }
+      const target = mapped.carrier
+        ? `${mapped.resolvedMode} carrier '${mapped.carrier}'`
+        : `${mapped.resolvedMode} carriers`;
       return errorResult(
-        "Fuel surcharge data is not yet available — the /v1/fuel-surcharge dataset may not be deployed yet. No surcharge value can be reported (this tool never estimates or fabricates one). Try again later, or see https://oilpriceapi.com for dataset availability.",
+        `Fuel surcharge data not available for ${target}. Use covered carrier slugs, and include service_level for parcel history. LTL carriers include odfl, saia, estes, xpo, abf, tforce, averitt, and southeastern-freight. Parcel carriers include ups, fedex, and dhl.`,
       );
     }
 
-    return textResult(formatFuelSurcharge(response.data));
+    return textResult(
+      formatFuelSurchargeData(response.data, {
+        mode: mapped.resolvedMode,
+        history: Boolean(history),
+      }),
+    );
   },
 );
 
@@ -4008,7 +4229,7 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("OilPriceAPI MCP Server v2.6.0 running on stdio");
+  console.error(`OilPriceAPI MCP Server v${MCP_VERSION} running on stdio`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Summary: Adds opa_get_fuel_surcharge for authenticated LTL and parcel carrier surcharge lookups, including endpoint mapping, formatting, keyless teaser behavior, README/tool-count metadata, and v2.6.0 manifests. Verification: npm test; npm run build; git diff --check.