### PR TITLE
fix: shorten MCP registry description

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.OilpriceAPI/mcp-server",
-  "description": "Real-time oil, gas & commodity data. 28 tools: spot, futures, drilling, wells, fuel surcharges, alerts.",
+  "description": "Oil, gas & commodity data. 28 tools: spot, futures, drilling, wells, surcharges, alerts.",
   "repository": {
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"


### PR DESCRIPTION
Summary: Shortens server.json description from 103 to 88 characters so the MCP registry publisher accepts the 2.6.0 metadata. npm 2.6.0 is already published; this unblocks registry backfill. Verification: jq description length = 88; server/package versions both 2.6.0; git diff --check.