### PR TITLE
chore(release): bump MCP server to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi-mcp",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "mcpName": "io.github.OilpriceAPI/mcp-server",
   "description": "Source-timestamped oil, gas, and related energy data plus reviewed product facts for MCP clients.",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump `oilpriceapi-mcp` from 2.6.0 to 2.6.1
- prepare the reviewed product-facts resource/tool from #51 for an npm/GitHub release

## Verification
- `npm test` (124 tests)
- `npm run test:product-facts`
- `git diff --check`

## Release
After this merges, publish GitHub release/tag `v2.6.1`; the trusted-publishing workflow will build, run the packaged discovery smoke, and publish to npm.

Refs #50.