### PR TITLE
fix(release): keep MCP registry metadata in sync

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: "22"
       - run: npm ci
+      - run: npm run verify:release-metadata
       - run: npm test
       - run: npm run build
       - run: npm run smoke:product-facts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify release metadata
+        run: npm run verify:release-metadata
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/registry-backfill.yml
+++ b/.github/workflows/registry-backfill.yml
@@ -20,24 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify server.json version matches package.json
-        run: |
-          PKG=$(jq -r .version package.json)
-          SRV=$(jq -r .version server.json)
-          SRVPKG=$(jq -r '.packages[0].version' server.json)
-          if [ "$PKG" != "$SRV" ] || [ "$PKG" != "$SRVPKG" ]; then
-            echo "::error::Version mismatch: package.json=$PKG server.json=$SRV packages[0]=$SRVPKG"
-            exit 1
-          fi
-          echo "Version check OK: $PKG"
-          # Registry rejects description > 100 chars (422) — the silent killer
-          # that kept 2.3.0 unpublished. Fail fast here instead.
-          DLEN=$(jq -r '.description | length' server.json)
-          if [ "$DLEN" -gt 100 ]; then
-            echo "::error::server.json description is $DLEN chars; registry max is 100"
-            exit 1
-          fi
-          echo "Description length OK: $DLEN"
+      - name: Verify release metadata
+        run: npm run verify:release-metadata
 
       - name: Verify version exists on npm (registry must never lead npm)
         run: |

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.2",
   "name": "oilpriceapi",
   "display_name": "OilPriceAPI — Oil, Gas & Commodity Prices",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Source-timestamped energy data and reviewed OilPriceAPI product facts for MCP clients.",
   "long_description": "OilPriceAPI tools and resources for latest available energy values, history, futures, refining spreads, carrier fuel surcharges, selected energy-intelligence datasets, alerts, market briefs, and a versioned public product contract. Keyless demo mode supports a limited commodity set. Dataset access and limits vary by plan and account entitlement.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:live": "node scripts/live-smoke.mjs",
     "smoke:product-facts": "node scripts/product-facts-smoke.mjs",
     "test:product-facts": "npm run build && npm run smoke:product-facts",
-    "prepublishOnly": "npm run build"
+    "verify:release-metadata": "node scripts/verify-release-metadata.mjs",
+    "prepublishOnly": "npm run verify:release-metadata && npm run build"
   },
   "files": [
     "build"

--- a/scripts/verify-release-metadata.mjs
+++ b/scripts/verify-release-metadata.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+async function readJson(path) {
+  return JSON.parse(
+    await readFile(new URL(`../${path}`, import.meta.url), "utf8"),
+  );
+}
+
+const [packageJson, packageLock, server, manifest] = await Promise.all([
+  readJson("package.json"),
+  readJson("package-lock.json"),
+  readJson("server.json"),
+  readJson("manifest.json"),
+]);
+
+const expected = packageJson.version;
+const versions = new Map([
+  ["package-lock.json", packageLock.version],
+  ["package-lock.json packages root", packageLock.packages?.[""]?.version],
+  ["server.json", server.version],
+  ["server.json npm package", server.packages?.[0]?.version],
+  ["manifest.json", manifest.version],
+]);
+
+const mismatches = [...versions].filter(([, version]) => version !== expected);
+if (mismatches.length > 0) {
+  const details = mismatches
+    .map(([name, version]) => `${name}=${version ?? "missing"}`)
+    .join(", ");
+  throw new Error(
+    `Release metadata must match package.json=${expected}: ${details}`,
+  );
+}
+
+const registryDescriptionLength = [...server.description].length;
+if (registryDescriptionLength > 100) {
+  throw new Error(
+    `server.json description is ${registryDescriptionLength} characters; registry maximum is 100`,
+  );
+}
+
+if (process.env.GITHUB_REF_TYPE === "tag") {
+  const expectedTag = `v${expected}`;
+  if (process.env.GITHUB_REF_NAME !== expectedTag) {
+    throw new Error(
+      `Release tag ${process.env.GITHUB_REF_NAME ?? "missing"} must match ${expectedTag}`,
+    );
+  }
+}
+
+console.log(`Release metadata verified at ${expected}.`);

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"
   },
-  "version": "2.6.0",
+  "version": "2.6.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "oilpriceapi-mcp",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- align `server.json` and `manifest.json` with the published npm `2.6.1` package
- add a structured release-metadata verifier covering package, lockfile, MCP registry, desktop manifest, registry description length, and release tag
- run the verifier in PR CI, npm prepublish, release publishing, and registry backfill

## Verification
- `npm run verify:release-metadata`
- wrong-tag negative check fails with the expected mismatch
- `npm test` (124 tests)
- `npm run test:product-facts`
- Prettier and `git diff --check`

## Recovery
After merge, run the existing MCP registry backfill workflow. npm `2.6.1` has already published successfully; only the official MCP registry follow-on failed.

Refs #50.