### PR TITLE
feat: ship MCP 3.0 safe scopes, doctor, and capabilities

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -28,6 +28,7 @@ jobs:
       - run: npm test
       - run: npm run build
       - run: npm run smoke:product-facts
+      - run: npm run smoke:package
       - run: npm pack --dry-run
 
   live:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Smoke packaged product-facts discovery
         run: npm run smoke:product-facts
 
+      - name: Smoke packed CLI, capability, scope, and protocol contracts
+        run: npm run smoke:package
+
       # Authentication via OIDC Trusted Publishing (configured on npmjs.com for
       # repo OilpriceAPI/mcp-server, workflow publish.yml, no environment).
       # No NODE_AUTH_TOKEN needed; OIDC also satisfies the package 2FA requirement

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ Backed by [OilPriceAPI](https://oilpriceapi.com), a normalized REST API for ener
 npx oilpriceapi-mcp
 ```
 
+The default scope is **read-only**. Account mutations are not listed and direct
+mutation calls are rejected unless write scope is explicitly enabled:
+
+```bash
+npx oilpriceapi-mcp --scope write
+```
+
+Inspect the package without opening an MCP stdio session:
+
+```bash
+npx oilpriceapi-mcp --version
+npx oilpriceapi-mcp --list-tools
+npx oilpriceapi-mcp --list-tools --json --profile core
+npx oilpriceapi-mcp doctor --demo
+npx oilpriceapi-mcp doctor
+npx oilpriceapi-mcp --capabilities --json
+```
+
 ## What can your agent get?
 
 Example commodity codes:
@@ -148,10 +166,54 @@ npm install -g oilpriceapi-mcp
 
 ## Environment Variables
 
-| Variable               | Required | Description                                                                                                                                                                                                                                                                                            |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `OILPRICEAPI_KEY`      | No       | API key from [oilpriceapi.com/signup](https://www.oilpriceapi.com/signup?utm_source=npm&utm_medium=mcp&utm_campaign=readme). After the core trial, the Free plan includes 200 requests/month. Dataset access and limits vary by plan and entitlement. Without a key, the server uses the limited demo. |
-| `OILPRICEAPI_BASE_URL` | No       | Override API base URL (for staging/testing). Default: `https://api.oilpriceapi.com`                                                                                                                                                                                                                    |
+| Variable                     | Required | Description                                                                                                                                                                                                                                                                                            |
+| ---------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `OILPRICEAPI_KEY`            | No       | API key from [oilpriceapi.com/signup](https://www.oilpriceapi.com/signup?utm_source=npm&utm_medium=mcp&utm_campaign=readme). After the core trial, the Free plan includes 200 requests/month. Dataset access and limits vary by plan and entitlement. Without a key, the server uses the limited demo. |
+| `OILPRICEAPI_BASE_URL`       | No       | Override API base URL (for staging/testing). Default: `https://api.oilpriceapi.com`                                                                                                                                                                                                                    |
+| `OILPRICEAPI_MCP_SCOPE`      | No       | `read` (default) hides and blocks create/delete tools. Set `write` only when account mutations are intended.                                                                                                                                                                                           |
+| `OILPRICEAPI_MCP_PROFILE`    | No       | Stable inventory profile: `all` (default), `core`, `market`, or `automation`.                                                                                                                                                                                                                          |
+| `OILPRICEAPI_MCP_CATEGORIES` | No       | Comma-separated category allowlist (`core`, `market`, `automation`). Overrides the selected profile.                                                                                                                                                                                                   |
+
+## Tool Scope and Profiles
+
+`read` scope includes all non-mutating tools, including alert history,
+subscription listing, and subscription event polling. The four create/delete
+tools require `--scope write` or `OILPRICEAPI_MCP_SCOPE=write`. Unknown scope,
+profile, or category values fail closed before stdio starts.
+
+Profiles reduce tool overload without replacing first-class MCP actions:
+
+| Profile      | Included categories      |
+| ------------ | ------------------------ |
+| `all`        | core, market, automation |
+| `core`       | core                     |
+| `market`     | core, market             |
+| `automation` | core, automation         |
+
+For example, a read-only price and product-facts server can use:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "oilpriceapi-mcp", "--scope", "read", "--profile", "core"]
+}
+```
+
+## Doctor and Capability Contract
+
+`doctor` checks the Node runtime, package entry point, API reachability, key
+validity, current plan, and reported feature gates. `doctor --demo` performs a
+bounded keyless request. Failures distinguish missing configuration, 401, 402,
+403, 429, timeout, DNS/TLS, and upstream 5xx responses. The API key is never
+printed.
+
+Every package includes `build/capabilities.json`. It is generated from the same
+SDK registry used by `tools/list` and records the package/version/source commit,
+minimum Node version, scopes, profiles, exact inventories, per-tool annotations,
+key/entitlement requirements, resources, commands, and support URLs. Website and
+docs consumers should pin a package version, validate `schemaVersion` and
+`sourceCommit`, and update the artifact only through an explicit dependency
+upgrade. They should not scrape CLI prose or hard-code tool counts.
 
 ## Tools
 
@@ -274,6 +336,14 @@ npm run build
 npm test
 OILPRICEAPI_KEY=your-key node build/index.js
 ```
+
+## Breaking Changes in v3.0.0
+
+- The default tool scope is now read-only. Create/delete alert and subscription
+  tools require explicit `--scope write` or `OILPRICEAPI_MCP_SCOPE=write`.
+- Invalid scope/profile/category configuration now fails before MCP stdio starts.
+- Use `--list-tools --json` or `--capabilities --json` instead of relying on a
+  hard-coded inventory.
 
 ## Breaking Changes in v2.0.0
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.2",
   "name": "oilpriceapi",
   "display_name": "OilPriceAPI — Oil, Gas & Commodity Prices",
-  "version": "2.6.1",
+  "version": "3.0.0",
   "description": "Source-timestamped energy data and reviewed OilPriceAPI product facts for MCP clients.",
   "long_description": "OilPriceAPI tools and resources for latest available energy values, history, futures, refining spreads, carrier fuel surcharges, selected energy-intelligence datasets, alerts, market briefs, and a versioned public product contract. Keyless demo mode supports a limited commodity set. Dataset access and limits vary by plan and account entitlement.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "2.6.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi-mcp",
-      "version": "2.6.1",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "2.6.1",
+  "version": "3.0.0",
   "mcpName": "io.github.OilpriceAPI/mcp-server",
   "description": "Source-timestamped oil, gas, and related energy data plus reviewed product facts for MCP clients.",
   "type": "module",
@@ -9,18 +9,24 @@
   },
   "main": "./build/index.js",
   "scripts": {
-    "build": "tsc && node scripts/copy-product-facts.mjs && chmod 755 build/index.js",
+    "build": "tsc && node scripts/copy-product-facts.mjs && node scripts/generate-build-metadata.mjs && node scripts/generate-capabilities.mjs && chmod 755 build/index.js",
     "dev": "tsc --watch",
     "start": "node build/index.js",
     "test": "vitest run",
     "test:live": "node scripts/live-smoke.mjs",
     "smoke:product-facts": "node scripts/product-facts-smoke.mjs",
+    "smoke:package": "node scripts/package-smoke.mjs",
     "test:product-facts": "npm run build && npm run smoke:product-facts",
     "verify:release-metadata": "node scripts/verify-release-metadata.mjs",
     "prepublishOnly": "npm run verify:release-metadata && npm run build"
   },
   "files": [
-    "build"
+    "build/*.d.ts",
+    "build/*.d.ts.map",
+    "build/*.js",
+    "build/*.js.map",
+    "build/*.json",
+    "build/*.sha256"
   ],
   "keywords": [
     "mcp",

--- a/scripts/generate-build-metadata.mjs
+++ b/scripts/generate-build-metadata.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = new URL("..", import.meta.url);
+
+async function git(...args) {
+  const { stdout } = await execFileAsync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+  });
+  return stdout.trim();
+}
+
+const environmentSha = process.env.GITHUB_SHA?.trim().toLowerCase();
+const sourceCommit = /^[0-9a-f]{40}$/.test(environmentSha || "")
+  ? environmentSha
+  : (await git("rev-parse", "HEAD")).toLowerCase();
+if (!/^[0-9a-f]{40}$/.test(sourceCommit)) {
+  throw new Error("Could not resolve a 40-character source commit.");
+}
+
+let generatedAt;
+if (process.env.SOURCE_DATE_EPOCH) {
+  generatedAt = new Date(
+    Number(process.env.SOURCE_DATE_EPOCH) * 1000,
+  ).toISOString();
+} else {
+  generatedAt = new Date(
+    await git("show", "-s", "--format=%cI", sourceCommit),
+  ).toISOString();
+}
+
+const output = new URL("../build/build-metadata.json", import.meta.url);
+await mkdir(new URL("../build", import.meta.url), { recursive: true });
+await writeFile(
+  output,
+  `${JSON.stringify({ sourceCommit, generatedAt }, null, 2)}\n`,
+  "utf8",
+);
+process.stdout.write(
+  `Generated deterministic build metadata for ${sourceCommit.slice(0, 8)}.\n`,
+);

--- a/scripts/generate-capabilities.mjs
+++ b/scripts/generate-capabilities.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = new URL("..", import.meta.url);
+const entryPoint = new URL("../build/index.js", import.meta.url);
+const output = new URL("../build/capabilities.json", import.meta.url);
+
+const { stdout, stderr } = await execFileAsync(
+  process.execPath,
+  [entryPoint.pathname, "--capabilities", "--json"],
+  { cwd: root, encoding: "utf8" },
+);
+if (stderr.trim()) {
+  throw new Error(`Capability generation wrote to stderr: ${stderr.trim()}`);
+}
+const manifest = JSON.parse(stdout);
+if (
+  manifest.schemaVersion !== "1.0.0" ||
+  !Array.isArray(manifest.tools) ||
+  manifest.tools.length === 0
+) {
+  throw new Error(
+    "Generated capability output does not match the v1 contract.",
+  );
+}
+
+await writeFile(output, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+const roundTrip = JSON.parse(await readFile(output, "utf8"));
+if (JSON.stringify(roundTrip) !== JSON.stringify(manifest)) {
+  throw new Error("Capability artifact changed during serialization.");
+}
+process.stdout.write(
+  `Generated capability manifest with ${manifest.tools.length} tools.\n`,
+);

--- a/scripts/generate-capabilities.mjs
+++ b/scripts/generate-capabilities.mjs
@@ -12,7 +12,11 @@ const output = new URL("../build/capabilities.json", import.meta.url);
 const { stdout, stderr } = await execFileAsync(
   process.execPath,
   [entryPoint.pathname, "--capabilities", "--json"],
-  { cwd: root, encoding: "utf8" },
+  {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, NODE_NO_WARNINGS: "1" },
+  },
 );
 if (stderr.trim()) {
   throw new Error(`Capability generation wrote to stderr: ${stderr.trim()}`);

--- a/scripts/live-smoke.mjs
+++ b/scripts/live-smoke.mjs
@@ -27,12 +27,9 @@
  * Auth: OILPRICEAPI_TEST_KEY (Bearer). SKIPS cleanly (exit 0) if absent so
  * forks / contributors without the secret are not blocked.
  *
- * Rate limit: the API allows 1 req/sec, so calls are spaced >= 1.1s apart.
- * Despite that spacing, CI shares a single 1-req/sec test key across repos, so
- * concurrent jobs elsewhere can still trip HTTP 429 (Too Many Requests) on our
- * calls. A 429 is rate-limit contention, NOT a regression, so each check treats
- * a 429 as a SKIP (logged, not counted as a failure) and the run still exits 0.
- * Only real errors (non-429: 4xx auth, 404, 5xx, malformed body) fail the run.
+ * The key belongs to a dedicated synthetic smoke identity. A quota preflight
+ * warns before 80% usage and refuses to start if the remaining allowance cannot
+ * complete the run. Calls are spaced >=1.1s apart; any 429 is a failed gate.
  */
 
 const API_BASE =
@@ -43,6 +40,8 @@ const RATE_LIMIT_MS = 1100; // > 1 req/sec
 // Opt-in: exercise the WRITE round-trip (create -> events -> delete) against
 // prod. Off by default so the standard CI run only reads.
 const WRITE_SUBSCRIPTIONS = process.env.SMOKE_WRITE_SUBSCRIPTIONS === "1";
+const EXPECTED_REQUESTS = WRITE_SUBSCRIPTIONS ? 12 : 8;
+const QUOTA_WARNING_PERCENT = 80;
 
 if (!KEY) {
   console.log(
@@ -61,7 +60,7 @@ async function request(path, { method = "GET", body, headers = {} } = {}) {
     headers: {
       Authorization: `Bearer ${KEY}`,
       Accept: "application/json",
-      "User-Agent": "oilpriceapi-mcp-live-smoke/2.3.0",
+      "User-Agent": "oilpriceapi-mcp-live-smoke/3.0.0",
       ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
       ...headers,
     },
@@ -89,10 +88,8 @@ function assert(cond, msg) {
   }
 }
 
-// Sentinel thrown when a live call is rate-limited (HTTP 429). The shared CI
-// test key is 1 req/sec across repos, so concurrent jobs elsewhere can 429 our
-// calls. That is contention, not a regression — callers catch this and SKIP
-// (no failure counted) instead of failing the run.
+// A dedicated smoke identity should not collide with customer or human traffic.
+// Any rate limit response is therefore an actionable gate failure.
 class RateLimited extends Error {
   constructor(label) {
     super(`rate-limited (HTTP 429): ${label}`);
@@ -101,7 +98,7 @@ class RateLimited extends Error {
 }
 
 // Throw RateLimited when a response is a 429 so the per-check try/catch can
-// distinguish a transient rate-limit (SKIP) from a real failure. Call this
+// distinguish a rate-limit failure from other failures. Call this
 // immediately after each live request, before asserting on the body.
 function rateLimitGuard(status, label) {
   if (status === 429) {
@@ -122,23 +119,20 @@ class PlanGated extends Error {
 
 // Throw PlanGated when a premium endpoint answers 402/403 so the per-check
 // try/catch can SKIP instead of failing. Only use on endpoints where the
-// shared CI key may legitimately lack the entitlement.
+// synthetic CI identity may legitimately lack the entitlement.
 function planGateGuard(status, label) {
   if (status === 402 || status === 403) {
     throw new PlanGated(label, status);
   }
 }
 
-// Centralised per-check error handling. Returns the new failure count: a 429
-// (RateLimited) or an entitlement 402/403 (PlanGated) is logged as a
-// tolerated SKIP and does NOT increment failures; any other error is a real
-// failure and increments.
+// Centralised per-check error handling. A 429 always increments failures.
+// PlanGated is used only for explicitly optional premium datasets; core market
+// brief and subscription-list checks do not call planGateGuard.
 function handleCheckError(err, failures) {
   if (err instanceof RateLimited) {
-    console.log(
-      `SKIP (rate-limited (shared CI key), skipping live assertion): ${err.message}`,
-    );
-    return failures;
+    console.error(`FAIL: ${err.message}`);
+    return failures + 1;
   }
   if (err instanceof PlanGated) {
     console.log(
@@ -149,8 +143,58 @@ function handleCheckError(err, failures) {
   return failures + 1;
 }
 
+async function quotaPreflight() {
+  const { status, body } = await getJson("/v1/account");
+  rateLimitGuard(status, "GET /v1/account quota preflight");
+  assert(status === 200, `account preflight expected 200, got ${status}`);
+  const account = body && typeof body === "object" ? body.account : null;
+  assert(
+    account && typeof account === "object",
+    "account preflight missing account summary",
+  );
+
+  const used = Number(account.usage_this_month);
+  const limit = Number(
+    account.effective_request_limit ?? account.request_limit,
+  );
+  const remaining = Number(account.remaining_requests);
+  assert(
+    Number.isFinite(used) &&
+      Number.isFinite(limit) &&
+      Number.isFinite(remaining),
+    "account preflight missing numeric quota counters",
+  );
+  assert(limit > 0, "account preflight returned a non-positive request limit");
+  assert(
+    remaining >= EXPECTED_REQUESTS,
+    `quota preflight has ${remaining} requests remaining; ${EXPECTED_REQUESTS} are required`,
+  );
+
+  const percentUsed = Math.round((used / limit) * 10000) / 100;
+  if (
+    percentUsed >= QUOTA_WARNING_PERCENT ||
+    remaining < EXPECTED_REQUESTS * 2
+  ) {
+    console.warn(
+      `WARN: synthetic smoke quota is ${percentUsed}% used (${remaining}/${limit} remaining)`,
+    );
+  }
+  const tier = typeof account.tier === "string" ? account.tier : "unknown";
+  console.log(
+    `PASS: synthetic smoke preflight -> plan ${tier}, quota ${used}/${limit}, ${remaining} remaining`,
+  );
+}
+
 async function main() {
   let failures = 0;
+
+  try {
+    await quotaPreflight();
+  } catch (err) {
+    console.error(`FAIL (quota preflight): ${err.message}`);
+    process.exit(1);
+  }
+  await sleep(RATE_LIMIT_MS);
 
   // 1. Latest — GET /v1/futures/{slug}
   // The API returns a top-level object: { front_month: { contract_month,
@@ -163,7 +207,7 @@ async function main() {
     assert(status === 200, `latest expected 200, got ${status}`);
     assert(
       body && typeof body === "object" && !body.error,
-      `latest returned an error/empty body: ${JSON.stringify(body)}`,
+      "latest returned an error or empty body",
     );
     const front =
       body.front_month ??
@@ -256,7 +300,7 @@ async function main() {
     const data = body && body.data;
     assert(
       data && Array.isArray(data.commodities) && data.commodities.length > 0,
-      `market-brief missing data.commodities: ${JSON.stringify(body)}`,
+      "market-brief missing data.commodities[]",
     );
     const brent = data.commodities.find((c) => c.code === "BRENT_CRUDE_USD");
     assert(brent, "market-brief missing BRENT_CRUDE_USD commodity");
@@ -288,7 +332,7 @@ async function main() {
     const subs = body && body.data && body.data.subscriptions;
     assert(
       Array.isArray(subs),
-      `subscriptions list missing data.subscriptions[]: ${JSON.stringify(body)}`,
+      "subscriptions list missing data.subscriptions[]",
     );
     console.log(
       `PASS: GET /v1/subscriptions -> 200, ${subs.length} subscription(s)`,
@@ -317,7 +361,7 @@ async function main() {
     const data = body && body.data;
     assert(
       data && Array.isArray(data.top_states) && data.top_states.length > 0,
-      `well-production missing data.top_states[]: ${JSON.stringify(body).slice(0, 300)}`,
+      "well-production missing data.top_states[]",
     );
     const top = data.top_states[0];
     assert(
@@ -352,7 +396,7 @@ async function main() {
     const data = body && body.data;
     assert(
       data && data.rig_counts && typeof data.rig_counts === "object",
-      `drilling missing data.rig_counts: ${JSON.stringify(body).slice(0, 300)}`,
+      "drilling missing data.rig_counts",
     );
     console.log(
       `PASS: GET /v1/drilling/latest -> 200, rig_counts keys: ${Object.keys(data.rig_counts).join(", ")}`,
@@ -386,7 +430,7 @@ async function main() {
       const carriers = body && body.data && body.data.carriers;
       assert(
         Array.isArray(carriers) && carriers.length > 0,
-        `fuel-surcharge missing data.carriers[]: ${JSON.stringify(body).slice(0, 300)}`,
+        "fuel-surcharge missing data.carriers[]",
       );
       const first = carriers[0];
       assert(
@@ -437,7 +481,7 @@ async function main() {
         created.body.subscription &&
         created.body.subscription.id;
       assert(createdId, "create did not return a subscription id");
-      console.log(`PASS: POST /v1/subscriptions -> created watch ${createdId}`);
+      console.log("PASS: POST /v1/subscriptions -> created synthetic watch");
 
       await sleep(RATE_LIMIT_MS);
       // List should now include it.
@@ -481,25 +525,22 @@ async function main() {
             { method: "DELETE" },
           );
           if (del.status === 204 || del.status === 200) {
-            console.log(
-              `PASS: DELETE /v1/subscriptions/${createdId} -> cleaned up`,
-            );
+            console.log("PASS: DELETE synthetic subscription -> cleaned up");
           } else if (del.status === 429) {
-            // Rate-limited cleanup is contention, not a regression. Do NOT fail
-            // the run, but surface that the watch may linger in prod.
-            console.log(
-              `SKIP (rate-limited (shared CI key), skipping live assertion): DELETE /v1/subscriptions/${createdId} -> 429 — watch may remain in prod`,
+            failures++;
+            console.error(
+              "FAIL (cleanup): DELETE synthetic subscription -> 429; cleanup must be retried",
             );
           } else {
             failures++;
             console.error(
-              `FAIL (cleanup): DELETE expected 200/204, got ${del.status} — watch ${createdId} may remain in prod`,
+              `FAIL (cleanup): DELETE expected 200/204, got ${del.status}; cleanup must be retried`,
             );
           }
         } catch (err) {
           failures++;
           console.error(
-            `FAIL (cleanup): ${err.message} — watch ${createdId} may remain in prod`,
+            `FAIL (cleanup): ${err.message}; synthetic watch cleanup must be retried`,
           );
         }
       }

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const execFileAsync = promisify(execFile);
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const packageJson = JSON.parse(
+  await readFile(join(root, "package.json"), "utf8"),
+);
+const temporary = await mkdtemp(join(tmpdir(), "oilpriceapi-mcp-package-"));
+const installRoot = join(temporary, "install");
+let server;
+
+function run(entryPoint, args, env = {}) {
+  return execFileAsync(process.execPath, [entryPoint, ...args], {
+    cwd: installRoot,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+function transportEnvironment(extra = {}) {
+  const environment = Object.fromEntries(
+    Object.entries(process.env).filter(([, value]) => value !== undefined),
+  );
+  delete environment.OILPRICEAPI_KEY;
+  delete environment.OIL_PRICE_API_KEY;
+  return { ...environment, ...extra };
+}
+
+async function assertProtocolScope(entryPoint, baseUrl, scope, expectedCount) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [entryPoint, "--scope", scope],
+    env: transportEnvironment({ OILPRICEAPI_BASE_URL: baseUrl }),
+    stderr: "pipe",
+  });
+  const client = new Client({
+    name: `oilpriceapi-package-${scope}-smoke`,
+    version: "1.0.0",
+  });
+  try {
+    await client.connect(transport);
+    const listed = await client.listTools();
+    if (listed.tools.length !== expectedCount) {
+      throw new Error(
+        `${scope} scope listed ${listed.tools.length} tools; expected ${expectedCount}`,
+      );
+    }
+    const writeName = "opa_create_price_alert";
+    const exposesWrite = listed.tools.some((tool) => tool.name === writeName);
+    if (scope === "read") {
+      if (exposesWrite) throw new Error("read scope exposed a mutation tool");
+      let rejected = false;
+      try {
+        const result = await client.callTool({
+          name: writeName,
+          arguments: {
+            commodity: "brent",
+            operator: "greater_than",
+            threshold: 100,
+          },
+        });
+        const errorText = Array.isArray(result.content)
+          ? result.content
+              .filter((item) => item.type === "text")
+              .map((item) => item.text)
+              .join(" ")
+          : "";
+        rejected =
+          result.isError === true && /disabled|not found/i.test(errorText);
+      } catch (error) {
+        rejected = /disabled|not found/i.test(String(error));
+      }
+      if (!rejected) {
+        throw new Error("read scope did not reject direct mutation invocation");
+      }
+    } else if (!exposesWrite) {
+      throw new Error("explicit write scope did not expose mutation tools");
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+try {
+  const { stdout: packOutput } = await execFileAsync(
+    "npm",
+    ["pack", "--json", "--pack-destination", temporary],
+    { cwd: root, encoding: "utf8" },
+  );
+  const packed = JSON.parse(packOutput);
+  if (packed[0].files.some((file) => file.path.includes("/__tests__/"))) {
+    throw new Error("The npm tarball contains compiled test artifacts.");
+  }
+  const tarball = join(temporary, packed[0].filename);
+  await execFileAsync(
+    "npm",
+    [
+      "install",
+      "--prefix",
+      installRoot,
+      "--ignore-scripts",
+      "--no-package-lock",
+      "--no-audit",
+      "--fund=false",
+      tarball,
+    ],
+    { encoding: "utf8" },
+  );
+
+  const entryPoint = join(
+    installRoot,
+    "node_modules",
+    packageJson.name,
+    "build",
+    "index.js",
+  );
+  const packagedCapabilities = JSON.parse(
+    await readFile(
+      join(
+        installRoot,
+        "node_modules",
+        packageJson.name,
+        "build",
+        "capabilities.json",
+      ),
+      "utf8",
+    ),
+  );
+
+  const version = await run(entryPoint, ["--version"]);
+  if (version.stdout.trim() !== `${packageJson.name} ${packageJson.version}`) {
+    throw new Error(
+      `Unexpected packaged --version output: ${version.stdout.trim()}`,
+    );
+  }
+
+  const readTools = JSON.parse(
+    (await run(entryPoint, ["--list-tools", "--json"])).stdout,
+  );
+  if (
+    readTools.scope !== "read" ||
+    readTools.tools.length !== 25 ||
+    readTools.tools.some((tool) => tool.access === "write")
+  ) {
+    throw new Error(
+      "Packaged default tool inventory is not read-only and exact.",
+    );
+  }
+
+  let invalidScopeFailedClosed = false;
+  try {
+    await run(entryPoint, ["--scope", "admin", "--list-tools", "--json"]);
+  } catch (error) {
+    invalidScopeFailedClosed =
+      error.code !== 0 &&
+      !error.stdout?.trim() &&
+      /Unknown MCP scope/i.test(error.stderr || "");
+  }
+  if (!invalidScopeFailedClosed) {
+    throw new Error("Packaged CLI did not fail closed on an unknown scope.");
+  }
+
+  const capabilities = JSON.parse(
+    (await run(entryPoint, ["--capabilities", "--json"])).stdout,
+  );
+  if (JSON.stringify(capabilities) !== JSON.stringify(packagedCapabilities)) {
+    throw new Error("Packaged capability command and artifact disagree.");
+  }
+  if (
+    capabilities.package.version !== packageJson.version ||
+    !/^[0-9a-f]{40}$/.test(capabilities.package.sourceCommit) ||
+    capabilities.package.minimumNodeVersion !== ">=18.0.0"
+  ) {
+    throw new Error("Packaged capability metadata is incomplete.");
+  }
+
+  server = createServer((request, response) => {
+    response.setHeader("Content-Type", "application/json");
+    if (request.url === "/health") {
+      response.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+    if (request.url === "/v1/demo/prices") {
+      response.end(
+        JSON.stringify({
+          status: "success",
+          data: { prices: [{ code: "BRENT_CRUDE_USD", price: 80 }] },
+        }),
+      );
+      return;
+    }
+    response.statusCode = 404;
+    response.end(JSON.stringify({ error: "not found" }));
+  });
+  await new Promise((resolveListen) =>
+    server.listen(0, "127.0.0.1", resolveListen),
+  );
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("No smoke server port");
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const doctor = JSON.parse(
+    (
+      await run(entryPoint, ["doctor", "--demo", "--json"], {
+        OILPRICEAPI_BASE_URL: baseUrl,
+      })
+    ).stdout,
+  );
+  if (!doctor.ok || doctor.checks.at(-1)?.id !== "demo") {
+    throw new Error("Packaged doctor --demo did not pass.");
+  }
+
+  await assertProtocolScope(entryPoint, baseUrl, "read", 25);
+  await assertProtocolScope(entryPoint, baseUrl, "write", 29);
+
+  process.stdout.write(
+    "packaged MCP smoke passed: version, doctor, capabilities, scopes, and protocol blocking\n",
+  );
+} finally {
+  if (server) await new Promise((resolveClose) => server.close(resolveClose));
+  await rm(temporary, { recursive: true, force: true });
+}

--- a/scripts/verify-release-metadata.mjs
+++ b/scripts/verify-release-metadata.mjs
@@ -14,6 +14,10 @@ const [packageJson, packageLock, server, manifest] = await Promise.all([
   readJson("server.json"),
   readJson("manifest.json"),
 ]);
+const source = await readFile(
+  new URL("../src/index.ts", import.meta.url),
+  "utf8",
+);
 
 const expected = packageJson.version;
 const versions = new Map([
@@ -31,6 +35,13 @@ if (mismatches.length > 0) {
     .join(", ");
   throw new Error(
     `Release metadata must match package.json=${expected}: ${details}`,
+  );
+}
+
+const sourceVersion = source.match(/export const MCP_VERSION = "([^"]+)"/)?.[1];
+if (sourceVersion !== expected) {
+  throw new Error(
+    `src/index.ts MCP_VERSION=${sourceVersion ?? "missing"} must match package.json=${expected}.`,
   );
 }
 

--- a/server.json
+++ b/server.json
@@ -36,6 +36,13 @@
           "format": "string",
           "isSecret": false,
           "name": "OILPRICEAPI_MCP_PROFILE"
+        },
+        {
+          "description": "Comma-separated category allowlist (core, market, automation) that overrides the profile.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "name": "OILPRICEAPI_MCP_CATEGORIES"
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"
   },
-  "version": "2.6.1",
+  "version": "3.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "oilpriceapi-mcp",
-      "version": "2.6.1",
+      "version": "3.0.0",
       "transport": {
         "type": "stdio"
       },
@@ -22,6 +22,20 @@
           "format": "string",
           "isSecret": true,
           "name": "OILPRICEAPI_KEY"
+        },
+        {
+          "description": "Tool scope: read (default) or write (explicit mutation opt-in).",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "name": "OILPRICEAPI_MCP_SCOPE"
+        },
+        {
+          "description": "Tool profile: all, core, market, or automation.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "name": "OILPRICEAPI_MCP_PROFILE"
         }
       ]
     }

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from "vitest";
+import { runDoctor } from "../doctor.js";
+
+const BASE_OPTIONS = {
+  baseUrl: "https://api.example.test",
+  apiKey: "test-key-must-stay-redacted",
+  entryPoint: process.execPath,
+  runtimeVersion: "v22.0.0",
+  timeoutMs: 50,
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("oilpriceapi-mcp doctor", () => {
+  it("checks runtime, launchability, API health, key validity, plan, and features", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(200, { status: "ok" }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          status: "success",
+          data: {
+            plan: "professional",
+            account: {
+              usage_this_month: 20,
+              effective_request_limit: 1000,
+              remaining_requests: 980,
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          status: "success",
+          data: {
+            billing: { plan: "professional" },
+            features: { webhooks: true, well_production: false },
+          },
+        }),
+      );
+
+    const report = await runDoctor({ ...BASE_OPTIONS, fetchImpl });
+
+    expect(report.ok).toBe(true);
+    expect(report.account).toEqual({
+      plan: "professional",
+      features: { webhooks: true, well_production: false },
+      quota: {
+        used: 20,
+        limit: 1000,
+        remaining: 980,
+        percentUsed: 2,
+      },
+    });
+    expect(report.checks.map((check) => check.id)).toEqual([
+      "runtime",
+      "package-launch",
+      "api-reachability",
+      "api-key",
+      "account",
+      "feature-gates",
+    ]);
+    expect(JSON.stringify(report)).not.toContain(BASE_OPTIONS.apiKey);
+  });
+
+  it("warns before quota exhaustion without exposing account identity", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(200, { status: "ok" }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          account: {
+            email: "must-not-appear@example.test",
+            tier: "synthetic-smoke",
+            usage_this_month: 850,
+            effective_request_limit: 1000,
+            remaining_requests: 150,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          data: { features: { subscriptions: true } },
+        }),
+      );
+
+    const report = await runDoctor({ ...BASE_OPTIONS, fetchImpl });
+    expect(report.ok).toBe(true);
+    expect(report.checks.find((check) => check.id === "account")).toMatchObject(
+      {
+        id: "account",
+        status: "warn",
+      },
+    );
+    expect(report.account?.quota?.percentUsed).toBe(85);
+    expect(JSON.stringify(report)).not.toContain(
+      "must-not-appear@example.test",
+    );
+  });
+
+  it("reports a locked dashboard feature with an exact access path", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(200, { status: "ok" }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, { account: { tier: "developer" } }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          data: { features: { webhooks: false, subscriptions: true } },
+        }),
+      );
+
+    const report = await runDoctor({ ...BASE_OPTIONS, fetchImpl });
+    expect(report.ok).toBe(true);
+    expect(report.checks.at(-1)).toMatchObject({
+      id: "feature-gates",
+      status: "warn",
+      message: expect.stringContaining("pricing"),
+    });
+    expect(report.account?.features).toEqual({
+      subscriptions: true,
+      webhooks: false,
+    });
+  });
+
+  it("runs a bounded keyless demo check without requiring a key", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(200, { status: "ok" }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          status: "success",
+          data: { prices: [{ code: "BRENT_CRUDE_USD", price: 80 }] },
+        }),
+      );
+
+    const report = await runDoctor({
+      ...BASE_OPTIONS,
+      apiKey: undefined,
+      demo: true,
+      fetchImpl,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.at(-1)).toMatchObject({ id: "demo", status: "pass" });
+    expect(fetchImpl.mock.calls[1][1]?.headers).not.toHaveProperty(
+      "Authorization",
+    );
+  });
+
+  it("reports missing configuration with a working recovery action", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse(200, { status: "ok" }));
+    const report = await runDoctor({
+      ...BASE_OPTIONS,
+      apiKey: undefined,
+      fetchImpl,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks.at(-1)).toMatchObject({
+      id: "api-key",
+      status: "fail",
+      recovery: expect.stringContaining("OILPRICEAPI_KEY"),
+    });
+  });
+
+  it.each([
+    [401, "authentication", "invalid"],
+    [402, "entitlement", "pricing"],
+    [403, "entitlement", "access"],
+    [429, "rate-limit", "retry"],
+    [503, "server", "service"],
+  ])(
+    "classifies HTTP %i account failures as %s",
+    async (status, classification, recoveryText) => {
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(jsonResponse(200, { status: "ok" }))
+        .mockResolvedValueOnce(jsonResponse(status, { error: "redacted" }));
+
+      const report = await runDoctor({ ...BASE_OPTIONS, fetchImpl });
+      const account = report.checks.find((check) => check.id === "account");
+
+      expect(report.ok).toBe(false);
+      expect(account).toMatchObject({ classification, status: "fail" });
+      expect(account?.recovery?.toLowerCase()).toContain(recoveryText);
+      expect(JSON.stringify(report)).not.toContain(BASE_OPTIONS.apiKey);
+    },
+  );
+
+  it("distinguishes timeouts from DNS/TLS transport failures", async () => {
+    const health = jsonResponse(200, { status: "ok" });
+    const timeoutFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(health)
+      .mockRejectedValueOnce(new DOMException("timed out", "AbortError"));
+    const timeout = await runDoctor({
+      ...BASE_OPTIONS,
+      fetchImpl: timeoutFetch,
+    });
+    expect(timeout.checks.at(-1)).toMatchObject({
+      classification: "timeout",
+      status: "fail",
+    });
+
+    const dnsError = new TypeError("fetch failed") as TypeError & {
+      cause?: { code: string };
+    };
+    dnsError.cause = { code: "ENOTFOUND" };
+    const dnsFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(200, { status: "ok" }))
+      .mockRejectedValueOnce(dnsError);
+    const dns = await runDoctor({ ...BASE_OPTIONS, fetchImpl: dnsFetch });
+    expect(dns.checks.at(-1)).toMatchObject({
+      classification: "dns-tls",
+      status: "fail",
+    });
+  });
+});

--- a/src/__tests__/toolRegistry.test.ts
+++ b/src/__tests__/toolRegistry.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { createSandboxServer } from "../index.js";
+import {
+  applyToolConfiguration,
+  buildCapabilityManifest,
+  getRegisteredToolEntries,
+  resolveToolConfiguration,
+  validateCapabilityManifest,
+  WRITE_TOOL_NAMES,
+} from "../toolRegistry.js";
+
+const BUILD_METADATA = {
+  name: "oilpriceapi-mcp",
+  version: "3.0.0",
+  minimumNodeVersion: ">=18.0.0",
+  repository: "https://github.com/OilpriceAPI/mcp-server",
+  sourceCommit: "0123456789abcdef0123456789abcdef01234567",
+  generatedAt: "2026-07-19T12:00:00.000Z",
+};
+
+describe("MCP tool scope and profiles", () => {
+  it("defaults to a read-only inventory and keeps all definitions registered", () => {
+    const server = createSandboxServer();
+    const configuration = resolveToolConfiguration({ argv: [], env: {} });
+    const enabled = applyToolConfiguration(server, configuration);
+    const registered = getRegisteredToolEntries(server);
+
+    expect(configuration).toMatchObject({ scope: "read", profile: "all" });
+    expect(registered).toHaveLength(29);
+    expect(enabled).toHaveLength(25);
+    expect(enabled).toContain("opa_list_price_alerts");
+    expect(enabled).toContain("opa_get_subscription_events");
+    for (const name of WRITE_TOOL_NAMES) {
+      expect(enabled).not.toContain(name);
+      expect(
+        registered.find(([toolName]) => toolName === name)?.[1].enabled,
+      ).toBe(false);
+    }
+  });
+
+  it("requires explicit write scope before mutation tools are enabled", () => {
+    const server = createSandboxServer();
+    const configuration = resolveToolConfiguration({
+      argv: ["--scope", "write"],
+      env: {},
+    });
+    const enabled = applyToolConfiguration(server, configuration);
+
+    expect(enabled).toHaveLength(29);
+    for (const name of WRITE_TOOL_NAMES) expect(enabled).toContain(name);
+  });
+
+  it("supports stable profiles and explicit category allowlists", () => {
+    const server = createSandboxServer();
+    const core = applyToolConfiguration(
+      server,
+      resolveToolConfiguration({ argv: ["--profile", "core"], env: {} }),
+    );
+    expect(core).toEqual([
+      "opa_compare_prices",
+      "opa_get_history",
+      "opa_get_price",
+      "opa_get_product_facts",
+      "opa_list_commodities",
+      "opa_market_overview",
+    ]);
+
+    const categories = applyToolConfiguration(
+      server,
+      resolveToolConfiguration({
+        argv: ["--scope", "write", "--categories", "automation"],
+        env: {},
+      }),
+    );
+    expect(categories).toContain("opa_create_price_alert");
+    expect(categories).toContain("opa_get_subscription_events");
+    expect(categories).not.toContain("opa_get_price");
+  });
+
+  it("fails closed on unknown scope, profile, or category values", () => {
+    expect(() =>
+      resolveToolConfiguration({ argv: ["--scope", "admin"], env: {} }),
+    ).toThrow(/Unknown MCP scope/i);
+    expect(() =>
+      resolveToolConfiguration({ argv: ["--profile", "everything"], env: {} }),
+    ).toThrow(/Unknown MCP profile/i);
+    expect(() =>
+      resolveToolConfiguration({
+        argv: ["--categories", "core,secrets"],
+        env: {},
+      }),
+    ).toThrow(/Unknown MCP tool category/i);
+  });
+});
+
+describe("generated MCP capability manifest", () => {
+  it("is deterministic, schema-valid, and agrees with every registered tool", () => {
+    const server = createSandboxServer();
+    const first = buildCapabilityManifest(server, BUILD_METADATA);
+    const second = buildCapabilityManifest(server, BUILD_METADATA);
+
+    expect(first).toEqual(second);
+    expect(validateCapabilityManifest(first)).toEqual(first);
+    expect(first.package).toMatchObject({
+      name: "oilpriceapi-mcp",
+      version: "3.0.0",
+      sourceCommit: BUILD_METADATA.sourceCommit,
+    });
+    expect(first.configuration.recommended).toEqual({
+      scope: "read",
+      profile: "all",
+    });
+    expect(first.tools).toHaveLength(29);
+    expect(first.tools.map((tool) => tool.name).sort()).toEqual(
+      getRegisteredToolEntries(server)
+        .map(([name]) => name)
+        .sort(),
+    );
+    expect(first.resources).toContainEqual(
+      expect.objectContaining({ uri: "oilpriceapi://product-facts" }),
+    );
+    expect(first.inventories.read.all).toHaveLength(25);
+    expect(first.inventories.write.all).toHaveLength(29);
+  });
+
+  it("contains no credential, account, prompt, or customer response data", () => {
+    process.env.OILPRICEAPI_KEY = "opa_live_never_include_this";
+    const manifest = buildCapabilityManifest(
+      createSandboxServer(),
+      BUILD_METADATA,
+    );
+    const serialized = JSON.stringify(manifest);
+
+    expect(serialized).not.toContain(process.env.OILPRICEAPI_KEY);
+    expect(serialized).not.toMatch(
+      /customerId|accountState|rawResponse|promptText/,
+    );
+    expect(serialized).toContain("OILPRICEAPI_KEY");
+    delete process.env.OILPRICEAPI_KEY;
+  });
+});

--- a/src/__tests__/toolRegistry.test.ts
+++ b/src/__tests__/toolRegistry.test.ts
@@ -91,6 +91,12 @@ describe("MCP tool scope and profiles", () => {
       }),
     ).toThrow(/Unknown MCP tool category/i);
   });
+
+  it("fails fast when MCP SDK registration internals are incompatible", () => {
+    expect(() => getRegisteredToolEntries({} as never)).toThrow(
+      /Incompatible MCP SDK/i,
+    );
+  });
 });
 
 describe("generated MCP capability manifest", () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,460 @@
+import { access } from "node:fs/promises";
+
+export type DoctorStatus = "pass" | "warn" | "fail";
+
+export interface DoctorCheck {
+  id: string;
+  status: DoctorStatus;
+  message: string;
+  classification?:
+    | "authentication"
+    | "entitlement"
+    | "rate-limit"
+    | "timeout"
+    | "dns-tls"
+    | "server"
+    | "http"
+    | "configuration";
+  recovery?: string;
+}
+
+export interface DoctorReport {
+  schemaVersion: "1.0.0";
+  ok: boolean;
+  mode: "account" | "demo";
+  checks: DoctorCheck[];
+  account?: {
+    plan: string;
+    features: Record<string, boolean>;
+    quota?: {
+      used: number;
+      limit: number;
+      remaining: number;
+      percentUsed: number;
+    };
+  };
+}
+
+export interface RunDoctorOptions {
+  baseUrl: string;
+  apiKey?: string;
+  demo?: boolean;
+  entryPoint: string;
+  runtimeVersion?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+const SIGNUP = "https://www.oilpriceapi.com/auth/signup?utm_source=mcp-doctor";
+const PRICING = "https://www.oilpriceapi.com/pricing?utm_source=mcp-doctor";
+const SUPPORT = "https://github.com/OilpriceAPI/mcp-server/issues";
+
+function runtimeMajor(version: string): number {
+  const match = version.match(/v?(\d+)/);
+  return match ? Number(match[1]) : 0;
+}
+
+function transportClassification(
+  error: unknown,
+): Pick<DoctorCheck, "classification" | "message" | "recovery"> {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return {
+      classification: "timeout",
+      message: "The OilPriceAPI request timed out.",
+      recovery:
+        "Retry after checking proxy/firewall settings and upstream service status.",
+    };
+  }
+
+  const cause = (error as { cause?: { code?: string } } | null)?.cause;
+  const code = cause?.code || "";
+  if (/^(ENOTFOUND|EAI_AGAIN|CERT_|ERR_TLS|UNABLE_TO_VERIFY)/.test(code)) {
+    return {
+      classification: "dns-tls",
+      message: "DNS or TLS negotiation failed before OilPriceAPI responded.",
+      recovery:
+        "Check DNS, HTTPS inspection, proxy certificates, and NODE_EXTRA_CA_CERTS where applicable.",
+    };
+  }
+
+  return {
+    classification: "dns-tls",
+    message: "The OilPriceAPI service could not be reached over HTTPS.",
+    recovery: `Check network, proxy, DNS, and TLS settings. Support: ${SUPPORT}`,
+  };
+}
+
+function httpFailure(status: number): DoctorCheck {
+  if (status === 401) {
+    return {
+      id: "account",
+      status: "fail",
+      classification: "authentication",
+      message: "OilPriceAPI rejected the configured key (HTTP 401).",
+      recovery: `The key is missing, invalid, stale, or revoked. Create or rotate it at ${SIGNUP}.`,
+    };
+  }
+  if (status === 402) {
+    return {
+      id: "account",
+      status: "fail",
+      classification: "entitlement",
+      message:
+        "The account is authenticated but its current plan cannot run this check (HTTP 402).",
+      recovery: `Review plan and entitlement requirements at ${PRICING}.`,
+    };
+  }
+  if (status === 403) {
+    return {
+      id: "account",
+      status: "fail",
+      classification: "entitlement",
+      message:
+        "The account is authenticated but access is forbidden (HTTP 403).",
+      recovery: `Request feature access or review the account plan at ${PRICING}.`,
+    };
+  }
+  if (status === 429) {
+    return {
+      id: "account",
+      status: "fail",
+      classification: "rate-limit",
+      message: "The account check was rate-limited (HTTP 429).",
+      recovery:
+        "Retry after the server-provided interval and verify account quota before running CI concurrently.",
+    };
+  }
+  if (status >= 500) {
+    return {
+      id: "account",
+      status: "fail",
+      classification: "server",
+      message: `OilPriceAPI returned a service error (HTTP ${status}).`,
+      recovery:
+        "Retry later and check OilPriceAPI service status before rotating a valid key.",
+    };
+  }
+  return {
+    id: "account",
+    status: "fail",
+    classification: "http",
+    message: `The account check returned unexpected HTTP ${status}.`,
+    recovery: `Review the endpoint contract or open a support issue: ${SUPPORT}`,
+  };
+}
+
+async function boundedFetch(
+  fetchImpl: typeof fetch,
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function safeAccount(body: unknown): NonNullable<DoctorReport["account"]> {
+  const envelope =
+    body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const data =
+    envelope.data && typeof envelope.data === "object"
+      ? (envelope.data as Record<string, unknown>)
+      : envelope;
+  const billing =
+    data.billing && typeof data.billing === "object"
+      ? (data.billing as Record<string, unknown>)
+      : {};
+  const account =
+    data.account && typeof data.account === "object"
+      ? (data.account as Record<string, unknown>)
+      : {};
+  const planCandidate = data.plan ?? billing.plan ?? data.tier ?? account.tier;
+  const plan =
+    typeof planCandidate === "string" && planCandidate.trim()
+      ? planCandidate.trim()
+      : "unknown";
+  const featureCandidate =
+    data.features ?? billing.features ?? account.features;
+  const features: Record<string, boolean> = {};
+  if (featureCandidate && typeof featureCandidate === "object") {
+    for (const [name, enabled] of Object.entries(
+      featureCandidate as Record<string, unknown>,
+    )) {
+      if (typeof enabled === "boolean") features[name] = enabled;
+      if (enabled && typeof enabled === "object" && !Array.isArray(enabled)) {
+        const detail = enabled as Record<string, unknown>;
+        if (typeof detail.enabled === "boolean") {
+          features[name] = detail.enabled;
+        }
+        for (const [childName, childEnabled] of Object.entries(detail)) {
+          if (name === "addons" && typeof childEnabled === "boolean") {
+            features[`${name}.${childName}`] = childEnabled;
+          }
+        }
+        for (const included of Array.isArray(detail.included)
+          ? detail.included
+          : []) {
+          if (typeof included === "string") features[included] = true;
+        }
+        for (const locked of Array.isArray(detail.locked)
+          ? detail.locked
+          : []) {
+          if (typeof locked === "string") features[locked] = false;
+        }
+      }
+    }
+  }
+  if (Array.isArray(featureCandidate)) {
+    for (const name of featureCandidate) {
+      if (typeof name === "string") features[name] = true;
+    }
+  }
+  const used = Number(account.usage_this_month);
+  const limit = Number(
+    account.effective_request_limit ?? account.request_limit,
+  );
+  const remaining = Number(account.remaining_requests);
+  const quota =
+    Number.isFinite(used) &&
+    Number.isFinite(limit) &&
+    limit > 0 &&
+    Number.isFinite(remaining)
+      ? {
+          used,
+          limit,
+          remaining,
+          percentUsed: Math.round((used / limit) * 10_000) / 100,
+        }
+      : undefined;
+  return { plan, features, ...(quota ? { quota } : {}) };
+}
+
+export async function runDoctor(
+  options: RunDoctorOptions,
+): Promise<DoctorReport> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? 8_000;
+  const runtimeVersion = options.runtimeVersion ?? process.version;
+  const checks: DoctorCheck[] = [];
+  const major = runtimeMajor(runtimeVersion);
+
+  checks.push(
+    major >= 18
+      ? {
+          id: "runtime",
+          status: "pass",
+          message: `Node ${runtimeVersion} satisfies the >=18 runtime requirement.`,
+        }
+      : {
+          id: "runtime",
+          status: "fail",
+          classification: "configuration",
+          message: `Node ${runtimeVersion} is unsupported.`,
+          recovery:
+            "Install Node 18 or newer and clear any stale npx cache entry.",
+        },
+  );
+
+  try {
+    await access(options.entryPoint);
+    checks.push({
+      id: "package-launch",
+      status: "pass",
+      message:
+        "The package entry point is readable; this invocation proves npx/package launchability.",
+    });
+  } catch {
+    checks.push({
+      id: "package-launch",
+      status: "fail",
+      classification: "configuration",
+      message: "The package entry point is missing or unreadable.",
+      recovery:
+        "Clear the npx cache and reinstall oilpriceapi-mcp from the npm registry.",
+    });
+  }
+
+  try {
+    const health = await boundedFetch(
+      fetchImpl,
+      `${options.baseUrl.replace(/\/$/, "")}/health`,
+      { headers: { Accept: "application/json" } },
+      timeoutMs,
+    );
+    if (!health.ok) {
+      checks.push({
+        id: "api-reachability",
+        status: "fail",
+        classification: health.status >= 500 ? "server" : "http",
+        message: `OilPriceAPI health returned HTTP ${health.status}.`,
+        recovery: "Check service status and proxy/firewall rules, then retry.",
+      });
+      return finish(options.demo ? "demo" : "account", checks);
+    }
+    checks.push({
+      id: "api-reachability",
+      status: "pass",
+      message: "OilPriceAPI health is reachable over HTTPS.",
+    });
+  } catch (error) {
+    checks.push({
+      id: "api-reachability",
+      status: "fail",
+      ...transportClassification(error),
+    });
+    return finish(options.demo ? "demo" : "account", checks);
+  }
+
+  if (options.demo) {
+    try {
+      const response = await boundedFetch(
+        fetchImpl,
+        `${options.baseUrl.replace(/\/$/, "")}/v1/demo/prices`,
+        { headers: { Accept: "application/json" } },
+        timeoutMs,
+      );
+      checks.push(
+        response.ok
+          ? {
+              id: "demo",
+              status: "pass",
+              message: "The bounded keyless demo request succeeded.",
+            }
+          : {
+              ...httpFailure(response.status),
+              id: "demo",
+            },
+      );
+    } catch (error) {
+      checks.push({
+        id: "demo",
+        status: "fail",
+        ...transportClassification(error),
+      });
+    }
+    return finish("demo", checks);
+  }
+
+  if (!options.apiKey) {
+    checks.push({
+      id: "api-key",
+      status: "fail",
+      classification: "configuration",
+      message: "OILPRICEAPI_KEY is not configured.",
+      recovery: `Set OILPRICEAPI_KEY or use doctor --demo. Create a key at ${SIGNUP}.`,
+    });
+    return finish("account", checks);
+  }
+
+  checks.push({
+    id: "api-key",
+    status: "pass",
+    message: "OILPRICEAPI_KEY is configured and remains redacted.",
+  });
+
+  try {
+    const response = await boundedFetch(
+      fetchImpl,
+      `${options.baseUrl.replace(/\/$/, "")}/v1/account`,
+      {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${options.apiKey}`,
+        },
+      },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      checks.push(httpFailure(response.status));
+      return finish("account", checks);
+    }
+    let account = safeAccount(await response.json());
+    const quotaExhausted = account.quota && account.quota.remaining <= 0;
+    const quotaWarning =
+      account.quota && !quotaExhausted && account.quota.percentUsed >= 80;
+    checks.push({
+      id: "account",
+      status: quotaExhausted ? "fail" : quotaWarning ? "warn" : "pass",
+      ...(quotaExhausted ? { classification: "rate-limit" as const } : {}),
+      message: quotaExhausted
+        ? `Account key is valid, but its monthly quota is exhausted on plan ${account.plan}.`
+        : quotaWarning
+          ? `Account key is valid on plan ${account.plan}; quota is ${account.quota?.percentUsed}% used with ${account.quota?.remaining} requests remaining.`
+          : `Account key is valid; current plan is ${account.plan}.`,
+      ...(quotaExhausted
+        ? {
+            recovery:
+              "Rotate to the dedicated synthetic smoke identity or raise its quota before running CI.",
+          }
+        : {}),
+    });
+    if (quotaExhausted) return finish("account", checks, account);
+
+    const dashboardResponse = await boundedFetch(
+      fetchImpl,
+      `${options.baseUrl.replace(/\/$/, "")}/v1/dashboard`,
+      {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${options.apiKey}`,
+        },
+      },
+      timeoutMs,
+    );
+    if (!dashboardResponse.ok) {
+      const failure = httpFailure(dashboardResponse.status);
+      checks.push({
+        ...failure,
+        id: "feature-gates",
+        message: `Feature-gate discovery failed. ${failure.message}`,
+      });
+      return finish("account", checks, account);
+    }
+
+    const dashboard = safeAccount(await dashboardResponse.json());
+    account = {
+      plan: dashboard.plan === "unknown" ? account.plan : dashboard.plan,
+      features: dashboard.features,
+      ...(account.quota ? { quota: account.quota } : {}),
+    };
+    const locked = Object.entries(account.features)
+      .filter(([, enabled]) => !enabled)
+      .map(([name]) => name)
+      .sort();
+    checks.push({
+      id: "feature-gates",
+      status: locked.length > 0 ? "warn" : "pass",
+      message:
+        locked.length > 0
+          ? `Locked features: ${locked.join(", ")}. Example recovery: request feature access or review ${PRICING}.`
+          : "Dashboard feature gates are readable; no disabled boolean gates were reported.",
+    });
+    return finish("account", checks, account);
+  } catch (error) {
+    checks.push({
+      id: "account",
+      status: "fail",
+      ...transportClassification(error),
+    });
+    return finish("account", checks);
+  }
+}
+
+function finish(
+  mode: DoctorReport["mode"],
+  checks: DoctorCheck[],
+  account?: DoctorReport["account"],
+): DoctorReport {
+  return {
+    schemaVersion: "1.0.0",
+    ok: !checks.some((check) => check.status === "fail"),
+    mode,
+    checks,
+    ...(account ? { account } : {}),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * OilPriceAPI MCP Server v2.6.0
+ * OilPriceAPI MCP Server v3.0.0
  *
  * Source-timestamped oil, gas, and related energy data for Claude, Cursor,
  * VS Code, and any MCP-compatible client.
@@ -43,8 +43,18 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { z } from "zod";
+import { runDoctor, type DoctorReport } from "./doctor.js";
 import { PRODUCT_FACTS_URI, ProductFactsProvider } from "./productFacts.js";
+import {
+  applyToolConfiguration,
+  buildCapabilityManifest,
+  resolveToolConfiguration,
+  type CapabilityBuildMetadata,
+  type ToolConfiguration,
+} from "./toolRegistry.js";
 
 export {
   PINNED_PRODUCT_FACTS,
@@ -58,7 +68,7 @@ export {
 // API Configuration
 const API_BASE =
   process.env.OILPRICEAPI_BASE_URL || "https://api.oilpriceapi.com";
-export const MCP_VERSION = "2.6.0";
+export const MCP_VERSION = "3.0.0";
 export const CLIENT_MARKER = `oilpriceapi-mcp/${MCP_VERSION}`;
 export const USER_AGENT = CLIENT_MARKER;
 
@@ -4302,13 +4312,192 @@ server.prompt(
   }),
 );
 
-// Smithery sandbox export for server scanning
-export function createSandboxServer() {
+const DEFAULT_TOOL_CONFIGURATION = resolveToolConfiguration({
+  argv: [],
+  env: {},
+});
+applyToolConfiguration(server, DEFAULT_TOOL_CONFIGURATION);
+
+// Smithery sandbox export for server scanning. Reset to the safe default for
+// every caller unless a test/integration explicitly requests another scope.
+export function createSandboxServer(configuration?: ToolConfiguration) {
+  applyToolConfiguration(server, configuration ?? DEFAULT_TOOL_CONFIGURATION);
   return server;
 }
 
+interface PackageJsonMetadata {
+  name: string;
+  version: string;
+  engines?: { node?: string };
+  repository?: { url?: string };
+}
+
+interface GeneratedBuildMetadata {
+  sourceCommit?: string;
+  generatedAt?: string;
+}
+
+function loadCapabilityBuildMetadata(): CapabilityBuildMetadata {
+  const packageJson = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  ) as PackageJsonMetadata;
+  let generated: GeneratedBuildMetadata = {};
+  try {
+    generated = JSON.parse(
+      readFileSync(new URL("./build-metadata.json", import.meta.url), "utf8"),
+    ) as GeneratedBuildMetadata;
+  } catch {
+    // Source imports do not have build metadata yet. The all-zero commit keeps
+    // local inspection schema-valid without claiming a source revision.
+  }
+
+  return {
+    name: packageJson.name,
+    version: packageJson.version,
+    minimumNodeVersion: packageJson.engines?.node || ">=18.0.0",
+    repository:
+      packageJson.repository?.url ||
+      "https://github.com/OilpriceAPI/mcp-server",
+    sourceCommit:
+      generated.sourceCommit || "0000000000000000000000000000000000000000",
+    generatedAt: generated.generatedAt || "1970-01-01T00:00:00.000Z",
+  };
+}
+
+function hasFlag(argv: string[], flag: string): boolean {
+  return argv.includes(flag);
+}
+
+function formatDoctor(report: DoctorReport): string {
+  const lines = [`OilPriceAPI MCP doctor (${report.mode})`];
+  for (const check of report.checks) {
+    lines.push(`${check.status.toUpperCase()} ${check.id}: ${check.message}`);
+    if (check.recovery) lines.push(`  Recovery: ${check.recovery}`);
+  }
+  if (report.account) {
+    lines.push(`Plan: ${report.account.plan}`);
+    const locked = Object.entries(report.account.features)
+      .filter(([, enabled]) => !enabled)
+      .map(([name]) => name)
+      .sort();
+    lines.push(
+      locked.length > 0
+        ? `Locked features: ${locked.join(", ")}`
+        : "Locked features: none reported",
+    );
+  }
+  lines.push(report.ok ? "Doctor result: PASS" : "Doctor result: FAIL");
+  return lines.join("\n");
+}
+
+function directExecution(): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    return (
+      realpathSync(process.argv[1]) ===
+      realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function validateCliArguments(argv: string[]): void {
+  const optionsWithValues = new Set(["--scope", "--profile", "--categories"]);
+  const standalone = new Set([
+    "--version",
+    "--list-tools",
+    "--capabilities",
+    "--json",
+    "--demo",
+    "doctor",
+  ]);
+  for (let index = 0; index < argv.length; index++) {
+    const value = argv[index];
+    if (
+      standalone.has(value) ||
+      [...optionsWithValues].some((name) => value.startsWith(`${name}=`))
+    ) {
+      continue;
+    }
+    if (optionsWithValues.has(value)) {
+      index += 1;
+      continue;
+    }
+    throw new Error(
+      `Unknown argument '${value}'. Run --list-tools or doctor --demo for diagnostics.`,
+    );
+  }
+}
+
 // Main entry point
-async function main() {
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  validateCliArguments(argv);
+  const configuration = resolveToolConfiguration({ argv, env: process.env });
+  const enabledTools = applyToolConfiguration(server, configuration);
+  const metadata = loadCapabilityBuildMetadata();
+
+  if (hasFlag(argv, "--version")) {
+    process.stdout.write(`${metadata.name} ${metadata.version}\n`);
+    return;
+  }
+
+  if (hasFlag(argv, "--capabilities")) {
+    const manifest = buildCapabilityManifest(server, metadata);
+    process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+    return;
+  }
+
+  if (hasFlag(argv, "--list-tools")) {
+    const manifest = buildCapabilityManifest(server, metadata);
+    const enabled = new Set(enabledTools);
+    const tools = manifest.tools.filter((tool) => enabled.has(tool.name));
+    if (hasFlag(argv, "--json")) {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            scope: configuration.scope,
+            profile: configuration.profile,
+            categories: configuration.categories,
+            tools,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else {
+      process.stdout.write(
+        [
+          `OilPriceAPI MCP tools (scope=${configuration.scope}, profile=${configuration.profile}, count=${tools.length})`,
+          ...tools.map(
+            (tool) =>
+              `${tool.name}\t${tool.access}\t${tool.category}\t${tool.title}`,
+          ),
+        ].join("\n") + "\n",
+      );
+    }
+    return;
+  }
+
+  if (argv.includes("doctor")) {
+    const report = await runDoctor({
+      baseUrl: API_BASE,
+      apiKey: getApiKey(),
+      demo: hasFlag(argv, "--demo"),
+      entryPoint: fileURLToPath(import.meta.url),
+    });
+    process.stdout.write(
+      hasFlag(argv, "--json")
+        ? `${JSON.stringify(report, null, 2)}\n`
+        : `${formatDoctor(report)}\n`,
+    );
+    if (!report.ok) process.exitCode = 1;
+    return;
+  }
+
+  console.error(
+    `OilPriceAPI MCP: scope=${configuration.scope} profile=${configuration.profile} tools=${enabledTools.length}/29`,
+  );
   if (!getApiKey()) {
     // stderr only — stdout is the MCP protocol channel.
     console.error(
@@ -4324,7 +4513,12 @@ async function main() {
   console.error(`OilPriceAPI MCP Server v${MCP_VERSION} running on stdio`);
 }
 
-main().catch((error) => {
-  console.error("Fatal error:", error);
-  process.exit(1);
-});
+if (directExecution()) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : "Unknown failure";
+    const key = getApiKey();
+    const redacted = key ? message.split(key).join("[REDACTED]") : message;
+    console.error(`OilPriceAPI MCP failed: ${redacted}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/toolRegistry.ts
+++ b/src/toolRegistry.ts
@@ -1,0 +1,445 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+export const TOOL_SCOPES = ["read", "write"] as const;
+export type ToolScope = (typeof TOOL_SCOPES)[number];
+
+export const TOOL_CATEGORIES = ["core", "market", "automation"] as const;
+export type ToolCategory = (typeof TOOL_CATEGORIES)[number];
+
+export const TOOL_PROFILES = {
+  all: TOOL_CATEGORIES,
+  core: ["core"],
+  market: ["core", "market"],
+  automation: ["core", "automation"],
+} as const satisfies Record<string, readonly ToolCategory[]>;
+export type ToolProfile = keyof typeof TOOL_PROFILES;
+
+export const WRITE_TOOL_NAMES = [
+  "opa_create_price_alert",
+  "opa_create_price_subscription",
+  "opa_delete_price_alert",
+  "opa_delete_subscription",
+] as const;
+
+const WRITE_TOOLS = new Set<string>(WRITE_TOOL_NAMES);
+
+const TOOL_CATEGORY_BY_NAME: Record<string, ToolCategory> = {
+  opa_get_product_facts: "core",
+  opa_get_price: "core",
+  opa_market_overview: "core",
+  opa_compare_prices: "core",
+  opa_list_commodities: "core",
+  opa_get_history: "core",
+  opa_get_futures: "market",
+  opa_get_futures_curve: "market",
+  opa_get_marine_fuels: "market",
+  opa_get_rig_counts: "market",
+  opa_get_drilling: "market",
+  opa_get_diesel_by_state: "market",
+  opa_get_fuel_surcharge: "market",
+  opa_get_storage: "market",
+  opa_get_opec_production: "market",
+  opa_get_forecasts: "market",
+  opa_get_oil_inventories: "market",
+  opa_get_well_permits: "market",
+  opa_get_well_production: "market",
+  opa_get_spread: "market",
+  opa_get_market_brief: "market",
+  opa_create_price_alert: "automation",
+  opa_list_price_alerts: "automation",
+  opa_delete_price_alert: "automation",
+  opa_get_alert_triggers: "automation",
+  opa_create_price_subscription: "automation",
+  opa_list_subscriptions: "automation",
+  opa_delete_subscription: "automation",
+  opa_get_subscription_events: "automation",
+};
+
+const KEYLESS_TOOLS = new Set([
+  "opa_get_product_facts",
+  "opa_get_price",
+  "opa_market_overview",
+  "opa_compare_prices",
+  "opa_list_commodities",
+]);
+
+interface RegisteredToolInternal {
+  title?: string;
+  description?: string;
+  annotations?: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
+  enabled: boolean;
+  enable: () => void;
+  disable: () => void;
+}
+
+interface RegisteredResourceInternal {
+  name: string;
+  title?: string;
+  metadata?: {
+    description?: string;
+    mimeType?: string;
+  };
+  enabled: boolean;
+}
+
+interface McpServerInternals {
+  _registeredTools: Record<string, RegisteredToolInternal>;
+  _registeredResources: Record<string, RegisteredResourceInternal>;
+}
+
+export interface ToolConfiguration {
+  scope: ToolScope;
+  profile: ToolProfile;
+  categories: ToolCategory[];
+  categoriesSource: "profile" | "allowlist";
+}
+
+export interface ResolveToolConfigurationOptions {
+  argv?: string[];
+  env?: Record<string, string | undefined>;
+}
+
+export interface CapabilityBuildMetadata {
+  name: string;
+  version: string;
+  minimumNodeVersion: string;
+  repository: string;
+  sourceCommit: string;
+  generatedAt: string;
+}
+
+function readOption(argv: string[], name: string): string | undefined {
+  const equalsPrefix = `${name}=`;
+  const equals = argv.find((value) => value.startsWith(equalsPrefix));
+  if (equals) return equals.slice(equalsPrefix.length);
+
+  const index = argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value.`);
+  }
+  return value;
+}
+
+function parseScope(value: string | undefined): ToolScope {
+  const scope = value?.trim().toLowerCase() || "read";
+  if (!TOOL_SCOPES.includes(scope as ToolScope)) {
+    throw new Error(
+      `Unknown MCP scope '${value}'. Expected one of: ${TOOL_SCOPES.join(", ")}.`,
+    );
+  }
+  return scope as ToolScope;
+}
+
+function parseProfile(value: string | undefined): ToolProfile {
+  const profile = value?.trim().toLowerCase() || "all";
+  if (!(profile in TOOL_PROFILES)) {
+    throw new Error(
+      `Unknown MCP profile '${value}'. Expected one of: ${Object.keys(TOOL_PROFILES).join(", ")}.`,
+    );
+  }
+  return profile as ToolProfile;
+}
+
+function parseCategories(value: string): ToolCategory[] {
+  const requested = [
+    ...new Set(value.split(",").map((item) => item.trim())),
+  ].filter(Boolean);
+  if (requested.length === 0) {
+    throw new Error("MCP tool category allowlist cannot be empty.");
+  }
+  const unknown = requested.filter(
+    (category) => !TOOL_CATEGORIES.includes(category as ToolCategory),
+  );
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown MCP tool category: ${unknown.join(", ")}. Expected: ${TOOL_CATEGORIES.join(", ")}.`,
+    );
+  }
+  return TOOL_CATEGORIES.filter((category) => requested.includes(category));
+}
+
+export function resolveToolConfiguration(
+  options: ResolveToolConfigurationOptions = {},
+): ToolConfiguration {
+  const argv = options.argv ?? [];
+  const env = options.env ?? process.env;
+  const scope = parseScope(
+    readOption(argv, "--scope") ?? env.OILPRICEAPI_MCP_SCOPE,
+  );
+  const profile = parseProfile(
+    readOption(argv, "--profile") ?? env.OILPRICEAPI_MCP_PROFILE,
+  );
+  const categoryValue =
+    readOption(argv, "--categories") ?? env.OILPRICEAPI_MCP_CATEGORIES;
+
+  return {
+    scope,
+    profile,
+    categories: categoryValue
+      ? parseCategories(categoryValue)
+      : [...TOOL_PROFILES[profile]],
+    categoriesSource: categoryValue ? "allowlist" : "profile",
+  };
+}
+
+function serverInternals(server: McpServer): McpServerInternals {
+  return server as unknown as McpServerInternals;
+}
+
+export function getRegisteredToolEntries(
+  server: McpServer,
+): Array<[string, RegisteredToolInternal]> {
+  const entries = Object.entries(serverInternals(server)._registeredTools).sort(
+    ([left], [right]) => left.localeCompare(right),
+  );
+  const registeredNames = new Set(entries.map(([name]) => name));
+  const missingCategories = entries
+    .map(([name]) => name)
+    .filter((name) => !TOOL_CATEGORY_BY_NAME[name]);
+  const staleCategories = Object.keys(TOOL_CATEGORY_BY_NAME).filter(
+    (name) => !registeredNames.has(name),
+  );
+  if (missingCategories.length > 0 || staleCategories.length > 0) {
+    throw new Error(
+      `Tool category registry drift. Missing: ${missingCategories.join(", ") || "none"}; stale: ${staleCategories.join(", ") || "none"}.`,
+    );
+  }
+  return entries;
+}
+
+export function toolNamesForConfiguration(
+  server: McpServer,
+  configuration: ToolConfiguration,
+): string[] {
+  const allowedCategories = new Set(configuration.categories);
+  return getRegisteredToolEntries(server)
+    .filter(([name]) => allowedCategories.has(TOOL_CATEGORY_BY_NAME[name]))
+    .filter(
+      ([name]) => configuration.scope === "write" || !WRITE_TOOLS.has(name),
+    )
+    .map(([name]) => name);
+}
+
+export function applyToolConfiguration(
+  server: McpServer,
+  configuration: ToolConfiguration,
+): string[] {
+  const enabledNames = new Set(
+    toolNamesForConfiguration(server, configuration),
+  );
+  for (const [name, tool] of getRegisteredToolEntries(server)) {
+    if (enabledNames.has(name)) tool.enable();
+    else tool.disable();
+  }
+  return [...enabledNames].sort();
+}
+
+const annotationSchema = z.object({
+  readOnlyHint: z.boolean().optional(),
+  destructiveHint: z.boolean().optional(),
+  idempotentHint: z.boolean().optional(),
+  openWorldHint: z.boolean().optional(),
+});
+
+const capabilityToolSchema = z.object({
+  name: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  category: z.enum(TOOL_CATEGORIES),
+  access: z.enum(["read", "write"]),
+  apiKey: z.enum(["none", "optional", "required"]),
+  entitlement: z.enum(["none", "account-and-plan-dependent"]),
+  annotations: annotationSchema,
+});
+
+export const capabilityManifestSchema = z.object({
+  schemaVersion: z.literal("1.0.0"),
+  generatedAt: z.string().datetime(),
+  package: z.object({
+    name: z.string().min(1),
+    version: z.string().min(1),
+    minimumNodeVersion: z.string().min(1),
+    repository: z.string().url(),
+    sourceCommit: z.string().regex(/^[0-9a-f]{40}$/),
+  }),
+  configuration: z.object({
+    recommended: z.object({
+      scope: z.literal("read"),
+      profile: z.literal("all"),
+    }),
+    client: z.object({
+      command: z.literal("npx"),
+      args: z.array(z.string()),
+      environment: z.array(
+        z.object({
+          name: z.string(),
+          required: z.boolean(),
+          secret: z.boolean(),
+          description: z.string(),
+        }),
+      ),
+    }),
+  }),
+  commands: z.object({
+    version: z.string(),
+    listTools: z.string(),
+    doctor: z.string(),
+    demoDoctor: z.string(),
+    capabilities: z.string(),
+  }),
+  profiles: z.record(z.string(), z.array(z.enum(TOOL_CATEGORIES))),
+  inventories: z.object({
+    read: z.record(z.string(), z.array(z.string())),
+    write: z.record(z.string(), z.array(z.string())),
+  }),
+  tools: z.array(capabilityToolSchema),
+  resources: z.array(
+    z.object({
+      name: z.string(),
+      uri: z.string(),
+      title: z.string().optional(),
+      description: z.string().optional(),
+      mimeType: z.string().optional(),
+    }),
+  ),
+  demo: z.object({
+    availableWithoutKey: z.literal(true),
+    endpoint: z.literal("/v1/demo/prices"),
+  }),
+  support: z.object({
+    documentation: z.string().url(),
+    issues: z.string().url(),
+    signup: z.string().url(),
+    pricing: z.string().url(),
+  }),
+});
+
+export type CapabilityManifest = z.infer<typeof capabilityManifestSchema>;
+
+function inventoryFor(
+  server: McpServer,
+  scope: ToolScope,
+): Record<ToolProfile, string[]> {
+  return Object.fromEntries(
+    Object.keys(TOOL_PROFILES).map((profile) => [
+      profile,
+      toolNamesForConfiguration(server, {
+        scope,
+        profile: profile as ToolProfile,
+        categories: [...TOOL_PROFILES[profile as ToolProfile]],
+        categoriesSource: "profile",
+      }),
+    ]),
+  ) as Record<ToolProfile, string[]>;
+}
+
+export function buildCapabilityManifest(
+  server: McpServer,
+  metadata: CapabilityBuildMetadata,
+): CapabilityManifest {
+  const resources = Object.entries(serverInternals(server)._registeredResources)
+    .filter(([, resource]) => resource.enabled)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([uri, resource]) => ({
+      name: resource.name,
+      uri,
+      title: resource.title,
+      description: resource.metadata?.description,
+      mimeType: resource.metadata?.mimeType,
+    }));
+
+  const manifest = {
+    schemaVersion: "1.0.0" as const,
+    generatedAt: metadata.generatedAt,
+    package: metadata,
+    configuration: {
+      recommended: { scope: "read" as const, profile: "all" as const },
+      client: {
+        command: "npx" as const,
+        args: ["-y", metadata.name, "--scope", "read"],
+        environment: [
+          {
+            name: "OILPRICEAPI_KEY",
+            required: false,
+            secret: true,
+            description:
+              "Optional OilPriceAPI key. Omit it for keyless demo and product-facts access.",
+          },
+          {
+            name: "OILPRICEAPI_MCP_SCOPE",
+            required: false,
+            secret: false,
+            description:
+              "Tool scope: read (default) or write (explicit opt-in).",
+          },
+          {
+            name: "OILPRICEAPI_MCP_PROFILE",
+            required: false,
+            secret: false,
+            description: "Tool profile: all, core, market, or automation.",
+          },
+        ],
+      },
+    },
+    commands: {
+      version: `${metadata.name} --version`,
+      listTools: `${metadata.name} --list-tools --json`,
+      doctor: `${metadata.name} doctor`,
+      demoDoctor: `${metadata.name} doctor --demo`,
+      capabilities: `${metadata.name} --capabilities --json`,
+    },
+    profiles: Object.fromEntries(
+      Object.entries(TOOL_PROFILES).map(([name, categories]) => [
+        name,
+        [...categories],
+      ]),
+    ),
+    inventories: {
+      read: inventoryFor(server, "read"),
+      write: inventoryFor(server, "write"),
+    },
+    tools: getRegisteredToolEntries(server).map(([name, tool]) => ({
+      name,
+      title: tool.title || name,
+      description: tool.description || "OilPriceAPI MCP tool",
+      category: TOOL_CATEGORY_BY_NAME[name],
+      access: WRITE_TOOLS.has(name) ? ("write" as const) : ("read" as const),
+      apiKey:
+        name === "opa_get_product_facts"
+          ? ("none" as const)
+          : KEYLESS_TOOLS.has(name)
+            ? ("optional" as const)
+            : ("required" as const),
+      entitlement:
+        name === "opa_get_product_facts"
+          ? ("none" as const)
+          : ("account-and-plan-dependent" as const),
+      annotations: tool.annotations || {},
+    })),
+    resources,
+    demo: {
+      availableWithoutKey: true as const,
+      endpoint: "/v1/demo/prices" as const,
+    },
+    support: {
+      documentation: "https://github.com/OilpriceAPI/mcp-server#readme",
+      issues: "https://github.com/OilpriceAPI/mcp-server/issues",
+      signup: "https://www.oilpriceapi.com/auth/signup?utm_source=mcp-doctor",
+      pricing: "https://www.oilpriceapi.com/pricing?utm_source=mcp-doctor",
+    },
+  };
+
+  return capabilityManifestSchema.parse(manifest);
+}
+
+export function validateCapabilityManifest(value: unknown): CapabilityManifest {
+  return capabilityManifestSchema.parse(value);
+}

--- a/src/toolRegistry.ts
+++ b/src/toolRegistry.ts
@@ -93,6 +93,10 @@ interface McpServerInternals {
   _registeredResources: Record<string, RegisteredResourceInternal>;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export interface ToolConfiguration {
   scope: ToolScope;
   profile: ToolProfile;
@@ -191,7 +195,16 @@ export function resolveToolConfiguration(
 }
 
 function serverInternals(server: McpServer): McpServerInternals {
-  return server as unknown as McpServerInternals;
+  const candidate = server as unknown as Partial<McpServerInternals>;
+  if (
+    !isRecord(candidate._registeredTools) ||
+    !isRecord(candidate._registeredResources)
+  ) {
+    throw new Error(
+      "Incompatible MCP SDK: expected registered tool and resource maps are unavailable.",
+    );
+  }
+  return candidate as McpServerInternals;
 }
 
 export function getRegisteredToolEntries(


### PR DESCRIPTION
## Summary

Release `oilpriceapi-mcp@3.0.0` with a fail-closed tool boundary and executable discovery/support contracts.

- default `read` scope lists 25 non-mutating tools and rejects direct mutation calls at MCP dispatch
- explicit `--scope write` / `OILPRICEAPI_MCP_SCOPE=write` enables all 29 tools
- stable `all`, `core`, `market`, and `automation` profiles plus category allowlists
- `--version`, `--list-tools [--json]`, `doctor [--demo] [--json]`, and `--capabilities --json` exit without opening stdio
- doctor classifies missing config, 401, 402, 403, 429, timeout, DNS/TLS, and 5xx; reports only sanitized plan/quota/feature gates
- deterministic `build/capabilities.json` is generated from the SDK registry used by `tools/list`
- package smoke installs the real tarball and verifies version, doctor, capability agreement, scope inventories, fail-closed invalid config, and protocol-level write blocking
- live CI now preflights synthetic-account quota, warns at 80%, fails before insufficient quota, and treats every 429 as a gate failure
- npm tarball allowlist excludes compiled test artifacts

## Breaking change

The default inventory is read-only. Existing clients that intentionally create or delete alerts/subscriptions must explicitly add `--scope write` or set `OILPRICEAPI_MCP_SCOPE=write`.

## Verification

- 141 unit tests
- TypeScript `--noEmit`
- release metadata and diff checks
- keyless product-facts MCP smoke
- packed-package MCP smoke
- npm dry run: 23 files, no compiled tests
- live `doctor --demo`
- authenticated production doctor on the dedicated Scale smoke identity
- two consecutive strict production live smokes; market brief and subscription listing returned 200 with no quota/entitlement/rate-limit skips
- repository `OILPRICEAPI_TEST_KEY` rotated at `2026-07-19T13:39:55Z`; obsolete local 402 key removed without exposing either value

Closes #45
Closes #46
Closes #47
Closes #50
Closes #53


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only tool access by default, with write actions available only when explicitly enabled.
  * Added configurable scopes, profiles, and category filters with safe failure for invalid settings.
  * Added `doctor` diagnostics, demo mode, JSON reporting, and capability inspection commands.
  * Added packaged capability metadata for easier validation and integration.

* **Documentation**
  * Expanded setup, configuration, troubleshooting, capability, and migration guidance.

* **Release**
  * Updated the MCP server to version 3.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->