### PR TITLE
fix: make the release package smoke npm 12 compatible

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,8 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
-        run: npm install -g npm@latest
+      - name: Install verified npm (OIDC trusted publishing needs npm >= 11.5.1)
+        run: npm install -g npm@11.12.1
 
       - name: Install dependencies
         run: npm ci

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -19,6 +19,24 @@ const temporary = await mkdtemp(join(tmpdir(), "oilpriceapi-mcp-package-"));
 const installRoot = join(temporary, "install");
 let server;
 
+function parsePackedPackage(output) {
+  const parsed = JSON.parse(output);
+  const candidates = Array.isArray(parsed) ? parsed : Object.values(parsed);
+  if (candidates.length !== 1) {
+    throw new Error(
+      `npm pack returned ${candidates.length} package records; expected exactly one.`,
+    );
+  }
+  const [packedPackage] = candidates;
+  if (
+    typeof packedPackage?.filename !== "string" ||
+    !Array.isArray(packedPackage.files)
+  ) {
+    throw new Error("npm pack returned an unsupported JSON record shape.");
+  }
+  return packedPackage;
+}
+
 function run(entryPoint, args, env = {}) {
   return execFileAsync(process.execPath, [entryPoint, ...args], {
     cwd: installRoot,
@@ -97,11 +115,11 @@ try {
     ["pack", "--json", "--pack-destination", temporary],
     { cwd: root, encoding: "utf8" },
   );
-  const packed = JSON.parse(packOutput);
-  if (packed[0].files.some((file) => file.path.includes("/__tests__/"))) {
+  const packed = parsePackedPackage(packOutput);
+  if (packed.files.some((file) => file.path.includes("/__tests__/"))) {
     throw new Error("The npm tarball contains compiled test artifacts.");
   }
-  const tarball = join(temporary, packed[0].filename);
+  const tarball = join(temporary, packed.filename);
   await execFileAsync(
     "npm",
     [


### PR DESCRIPTION
## Summary

- accept both npm 11 array and npm 12 keyed-object `npm pack --json` output
- validate that exactly one well-formed package record is returned
- pin the publishing runner to verified npm 11.12.1 instead of floating `latest`

## Production failure

Release run 29689867680 stopped before npm publish because npm 12 returned the new object shape and the smoke assumed an array.

## Verification

- Node 22.23.1 + npm 12.0.1 packaged protocol smoke: pass
- Node 22.23.1 + npm 11.12.1 packaged protocol smoke: pass
- 142 tests: pass
- TypeScript: pass
- build and product-facts protocol smoke: pass