### PR TITLE
feat: generate secret-safe MCP client configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,17 @@ npx oilpriceapi-mcp --list-tools --json --profile core
 npx oilpriceapi-mcp doctor --demo
 npx oilpriceapi-mcp doctor
 npx oilpriceapi-mcp --capabilities --json
+npx oilpriceapi-mcp --config claude-code
+npx oilpriceapi-mcp --config vscode
 ```
+
+`--config` generates client-native, copy/paste-valid JSON for
+`claude-desktop`, `claude-code`, `cursor`, `vscode`, `cline`, or `windsurf`.
+It never reads or prints the configured API key. Claude Code, VS Code, and
+Windsurf outputs use their supported environment or secure-input references;
+Claude Desktop, Cursor, and Cline use an explicit local replacement marker.
+Add `--demo` to omit API-key configuration entirely. Scope, profile, and
+category options are preserved in the generated server arguments.
 
 ## What can your agent get?
 

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -202,6 +202,42 @@ try {
     throw new Error("Packaged capability metadata is incomplete.");
   }
 
+  const configClients = [
+    "claude-desktop",
+    "claude-code",
+    "cursor",
+    "vscode",
+    "cline",
+    "windsurf",
+  ];
+  const configSecret = "opa_live_package_smoke_must_stay_redacted";
+  for (const client of configClients) {
+    const generated = await run(entryPoint, ["--config", client], {
+      OILPRICEAPI_KEY: configSecret,
+    });
+    JSON.parse(generated.stdout);
+    if (
+      generated.stdout.includes(configSecret) ||
+      !generated.stdout.includes(packageJson.name)
+    ) {
+      throw new Error(
+        `Packaged ${client} config was invalid or exposed the environment key.`,
+      );
+    }
+  }
+  let missingConfigTargetFailedClosed = false;
+  try {
+    await run(entryPoint, ["--config"]);
+  } catch (error) {
+    missingConfigTargetFailedClosed =
+      error.code !== 0 &&
+      !error.stdout?.trim() &&
+      /--config requires a value/i.test(error.stderr || "");
+  }
+  if (!missingConfigTargetFailedClosed) {
+    throw new Error("Packaged --config command did not fail closed.");
+  }
+
   server = createServer((request, response) => {
     response.setHeader("Content-Type", "application/json");
     if (request.url === "/health") {
@@ -243,7 +279,7 @@ try {
   await assertProtocolScope(entryPoint, baseUrl, "write", 32);
 
   process.stdout.write(
-    "packaged MCP smoke passed: version, doctor, capabilities, scopes, and protocol blocking\n",
+    "packaged MCP smoke passed: version, configs, doctor, capabilities, scopes, and protocol blocking\n",
   );
 } finally {
   if (server) await new Promise((resolveClose) => server.close(resolveClose));

--- a/src/__tests__/clientConfig.test.ts
+++ b/src/__tests__/clientConfig.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLIENT_CONFIG_TARGETS,
+  generateClientConfig,
+  type ClientConfigTarget,
+} from "../clientConfig.js";
+
+const TARGETS = Object.keys(CLIENT_CONFIG_TARGETS) as ClientConfigTarget[];
+
+describe("MCP client config generator", () => {
+  it("covers every supported client with deterministic, copy/paste-valid JSON", () => {
+    expect(TARGETS).toEqual([
+      "claude-desktop",
+      "claude-code",
+      "cursor",
+      "vscode",
+      "cline",
+      "windsurf",
+    ]);
+
+    for (const client of TARGETS) {
+      const first = generateClientConfig({ client });
+      const second = generateClientConfig({ client });
+      expect(first).toEqual(second);
+      expect(JSON.parse(JSON.stringify(first))).toEqual(first);
+      expect(JSON.stringify(first)).toContain("oilpriceapi-mcp");
+      expect(JSON.stringify(first)).toContain("--scope");
+      expect(JSON.stringify(first)).toContain("read");
+    }
+  });
+
+  it("never reads or emits the configured API key", () => {
+    process.env.OILPRICEAPI_KEY = "opa_live_must_never_be_printed";
+    try {
+      for (const client of TARGETS) {
+        const serialized = JSON.stringify(generateClientConfig({ client }));
+        expect(serialized).not.toContain(process.env.OILPRICEAPI_KEY);
+      }
+    } finally {
+      delete process.env.OILPRICEAPI_KEY;
+    }
+  });
+
+  it("uses client-supported secret references instead of hard-coded keys", () => {
+    expect(
+      JSON.stringify(generateClientConfig({ client: "claude-code" })),
+    ).toContain("${OILPRICEAPI_KEY}");
+    expect(
+      JSON.stringify(generateClientConfig({ client: "windsurf" })),
+    ).toContain("${env:OILPRICEAPI_KEY}");
+    expect(
+      JSON.stringify(generateClientConfig({ client: "vscode" })),
+    ).toContain("${input:oilpriceapi-key}");
+    expect(
+      JSON.stringify(generateClientConfig({ client: "cursor" })),
+    ).toContain("PASTE_OILPRICEAPI_KEY_HERE");
+    expect(
+      JSON.stringify(generateClientConfig({ client: "cline" })),
+    ).toContain("PASTE_OILPRICEAPI_KEY_HERE");
+  });
+
+  it("omits API-key configuration in demo mode", () => {
+    for (const client of TARGETS) {
+      const serialized = JSON.stringify(
+        generateClientConfig({ client, demo: true }),
+      );
+      expect(serialized).not.toContain("OILPRICEAPI_KEY");
+      expect(serialized).not.toContain("oilpriceapi-key");
+      expect(serialized).not.toContain("PASTE_");
+    }
+  });
+
+  it("preserves explicit scope and profile selections", () => {
+    const serialized = JSON.stringify(
+      generateClientConfig({
+        client: "cursor",
+        scope: "write",
+        profile: "automation",
+        categories: ["core", "automation"],
+      }),
+    );
+    expect(serialized).toContain('"--scope","write"');
+    expect(serialized).toContain('"--profile","automation"');
+    expect(serialized).toContain('"--categories","core,automation"');
+  });
+});

--- a/src/clientConfig.ts
+++ b/src/clientConfig.ts
@@ -1,0 +1,125 @@
+import type {
+  ToolCategory,
+  ToolProfile,
+  ToolScope,
+} from "./toolRegistry.js";
+
+export const CLIENT_CONFIG_TARGETS = {
+  "claude-desktop": "claude_desktop_config.json",
+  "claude-code": ".mcp.json",
+  cursor: ".cursor/mcp.json",
+  vscode: ".vscode/mcp.json",
+  cline: "cline_mcp_settings.json",
+  windsurf: "~/.codeium/windsurf/mcp_config.json",
+} as const;
+
+export type ClientConfigTarget = keyof typeof CLIENT_CONFIG_TARGETS;
+
+export interface GenerateClientConfigOptions {
+  client: ClientConfigTarget;
+  packageName?: string;
+  scope?: ToolScope;
+  profile?: ToolProfile;
+  categories?: ToolCategory[];
+  demo?: boolean;
+}
+
+interface StdioServerConfig {
+  type?: "stdio";
+  command: "npx";
+  args: string[];
+  env?: { OILPRICEAPI_KEY: string };
+  autoApprove?: string[];
+  disabled?: boolean;
+  timeout?: number;
+  transportType?: "stdio";
+}
+
+function stdioServer(
+  options: GenerateClientConfigOptions,
+  secretReference?: string,
+): StdioServerConfig {
+  const args = [
+    "-y",
+    options.packageName ?? "oilpriceapi-mcp",
+    "--scope",
+    options.scope ?? "read",
+    "--profile",
+    options.profile ?? "all",
+  ];
+  if (options.categories?.length) {
+    args.push("--categories", options.categories.join(","));
+  }
+  return {
+    command: "npx",
+    args,
+    ...(!options.demo && secretReference
+      ? { env: { OILPRICEAPI_KEY: secretReference } }
+      : {}),
+  };
+}
+
+export function isClientConfigTarget(
+  value: string,
+): value is ClientConfigTarget {
+  return value in CLIENT_CONFIG_TARGETS;
+}
+
+/**
+ * Build a client-native JSON object without ever reading the process
+ * environment. Clients with documented interpolation or secure inputs use
+ * those mechanisms; clients that require literal env values receive an
+ * unmistakable local replacement marker.
+ */
+export function generateClientConfig(
+  options: GenerateClientConfigOptions,
+): Record<string, unknown> {
+  if (options.client === "vscode") {
+    const server = {
+      type: "stdio" as const,
+      ...stdioServer(
+        options,
+        options.demo ? undefined : "${input:oilpriceapi-key}",
+      ),
+    };
+    return {
+      ...(!options.demo
+        ? {
+            inputs: [
+              {
+                type: "promptString",
+                id: "oilpriceapi-key",
+                description: "OilPriceAPI API key",
+                password: true,
+              },
+            ],
+          }
+        : {}),
+      servers: { oilpriceapi: server },
+    };
+  }
+
+  const secretReference =
+    options.client === "claude-code"
+      ? "${OILPRICEAPI_KEY}"
+      : options.client === "windsurf"
+        ? "${env:OILPRICEAPI_KEY}"
+        : "PASTE_OILPRICEAPI_KEY_HERE";
+  const server = stdioServer(options, secretReference);
+
+  if (options.client === "cline") {
+    return {
+      mcpServers: {
+        oilpriceapi: {
+          ...server,
+          autoApprove: [],
+          disabled: false,
+          timeout: 60,
+          transportType: "stdio",
+        },
+      },
+    };
+  }
+
+  return { mcpServers: { oilpriceapi: server } };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,11 @@ import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
 import { runDoctor, type DoctorReport } from "./doctor.js";
+import {
+  CLIENT_CONFIG_TARGETS,
+  generateClientConfig,
+  isClientConfigTarget,
+} from "./clientConfig.js";
 import { PRODUCT_FACTS_URI, ProductFactsProvider } from "./productFacts.js";
 import {
   currentToolAttributionHeaders,
@@ -4830,6 +4835,14 @@ function hasFlag(argv: string[], flag: string): boolean {
   return argv.includes(flag);
 }
 
+function cliOption(argv: string[], name: string): string | undefined {
+  const equalsPrefix = `${name}=`;
+  const equals = argv.find((value) => value.startsWith(equalsPrefix));
+  if (equals) return equals.slice(equalsPrefix.length);
+  const index = argv.indexOf(name);
+  return index === -1 ? undefined : argv[index + 1];
+}
+
 function formatDoctor(report: DoctorReport): string {
   const lines = [`OilPriceAPI MCP doctor (${report.mode})`];
   for (const check of report.checks) {
@@ -4865,7 +4878,12 @@ function directExecution(): boolean {
 }
 
 function validateCliArguments(argv: string[]): void {
-  const optionsWithValues = new Set(["--scope", "--profile", "--categories"]);
+  const optionsWithValues = new Set([
+    "--scope",
+    "--profile",
+    "--categories",
+    "--config",
+  ]);
   const standalone = new Set([
     "--version",
     "--list-tools",
@@ -4883,6 +4901,10 @@ function validateCliArguments(argv: string[]): void {
       continue;
     }
     if (optionsWithValues.has(value)) {
+      const optionValue = argv[index + 1];
+      if (!optionValue || optionValue.startsWith("--")) {
+        throw new Error(`${value} requires a value.`);
+      }
       index += 1;
       continue;
     }
@@ -4901,6 +4923,31 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 
   if (hasFlag(argv, "--version")) {
     process.stdout.write(`${metadata.name} ${metadata.version}\n`);
+    return;
+  }
+
+  const configTarget = cliOption(argv, "--config");
+  if (configTarget !== undefined) {
+    if (!isClientConfigTarget(configTarget)) {
+      throw new Error(
+        `Unknown MCP client '${configTarget}'. Expected one of: ${Object.keys(CLIENT_CONFIG_TARGETS).join(", ")}.`,
+      );
+    }
+    process.stdout.write(
+      `${JSON.stringify(
+        generateClientConfig({
+          client: configTarget,
+          scope: configuration.scope,
+          profile: configuration.profile,
+          ...(configuration.categoriesSource === "allowlist"
+            ? { categories: configuration.categories }
+            : {}),
+          demo: hasFlag(argv, "--demo"),
+        }),
+        null,
+        2,
+      )}\n`,
+    );
     return;
   }
 

--- a/src/toolRegistry.ts
+++ b/src/toolRegistry.ts
@@ -310,6 +310,7 @@ export const capabilityManifestSchema = z.object({
     doctor: z.string(),
     demoDoctor: z.string(),
     capabilities: z.string(),
+    config: z.string(),
   }),
   profiles: z.record(z.string(), z.array(z.enum(TOOL_CATEGORIES))),
   inventories: z.object({
@@ -411,6 +412,7 @@ export function buildCapabilityManifest(
       doctor: `${metadata.name} doctor`,
       demoDoctor: `${metadata.name} doctor --demo`,
       capabilities: `${metadata.name} --capabilities --json`,
+      config: `${metadata.name} --config <client>`,
     },
     profiles: Object.fromEntries(
       Object.entries(TOOL_PROFILES).map(([name, categories]) => [


### PR DESCRIPTION
## Outcome

Adds a deterministic, secret-safe config generator for every client named in OilpriceAPI/oilpriceapi-api#4793.

## Changes

- add `--config` for Claude Desktop, Claude Code, Cursor, VS Code, Cline, and Windsurf
- use supported environment interpolation or secure inputs where available
- use an explicit local replacement marker for clients that require literal env values
- add `--demo` output that omits API-key configuration
- preserve explicit read/write scope, profile, and category allowlists
- fail closed for missing or unknown client names
- record the generator in the capability manifest and package smoke

## Verification

- `npm test` — 163 passing
- `npm run build` — 32-tool manifest generated
- `npm run smoke:package` — version, configs, doctor, capabilities, scopes, and protocol blocking pass
- generated JSON manually inspected for Claude Code, VS Code, Windsurf demo, and invalid-client failure

This merge does not publish an npm package or trigger a core frontend/backend deployment.

Addresses the remaining config-generator portion of OilpriceAPI/oilpriceapi-api#4793.