### PR TITLE
fix(seo): expose canonical MCP directory sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Backed by [OilPriceAPI](https://oilpriceapi.com), a normalized REST API for energy dashboards, fleet and logistics tools, maritime workflows, and market research.
 
+**Canonical sources:** [Public product facts](https://api.oilpriceapi.com/product-facts.json) · [Official MCP Registry record](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.OilpriceAPI%2Fmcp-server/versions/latest)
+
 ## Features
 
 - **Reviewed product facts** — a keyless read-only tool and stable resource for offer, freshness, authentication, catalog, entitlement, and data-rights questions
@@ -178,7 +180,7 @@ npm install -g oilpriceapi-mcp
 
 | Variable                     | Required | Description                                                                                                                                                                                                                                                                                            |
 | ---------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `OILPRICEAPI_KEY`            | No       | API key from [oilpriceapi.com/signup](https://www.oilpriceapi.com/signup?utm_source=npm&utm_medium=mcp&utm_campaign=readme). After the core trial, the Free plan includes 200 requests/month. Dataset access and limits vary by plan and entitlement. Without a key, the server uses the limited demo. |
+| `OILPRICEAPI_KEY`            | No       | API key from [oilpriceapi.com/auth/signup](https://www.oilpriceapi.com/auth/signup?utm_source=npm&utm_medium=mcp&utm_campaign=readme). After the core trial, the Free plan includes 200 requests/month. Dataset access and limits vary by plan and entitlement. Without a key, the server uses the limited demo. |
 | `OILPRICEAPI_BASE_URL`       | No       | Override API base URL (for staging/testing). Default: `https://api.oilpriceapi.com`                                                                                                                                                                                                                    |
 | `OILPRICEAPI_MCP_SCOPE`      | No       | `read` (default) hides and blocks create/delete tools. Set `write` only when account mutations are intended.                                                                                                                                                                                           |
 | `OILPRICEAPI_MCP_PROFILE`    | No       | Stable inventory profile: `all` (default), `core`, `market`, or `automation`.                                                                                                                                                                                                                          |

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
       },
       "environmentVariables": [
         {
-          "description": "Your OilPriceAPI key from oilpriceapi.com/signup. Optional: without it, keyless demo mode.",
+          "description": "Your OilPriceAPI key from oilpriceapi.com/auth/signup. Optional: without it, keyless demo mode.",
           "isRequired": false,
           "format": "string",
           "isSecret": true,

--- a/src/__tests__/directorySource.test.ts
+++ b/src/__tests__/directorySource.test.ts
@@ -24,5 +24,8 @@ describe("directory-facing source metadata", () => {
       (entry: { name: string }) => entry.name === "OILPRICEAPI_KEY",
     ).description;
     expect(apiKeyDescription).toContain("oilpriceapi.com/auth/signup");
+    expect(apiKeyDescription).not.toMatch(
+      /oilpriceapi\.com\/signup(?:\?|\b)/i,
+    );
   });
 });

--- a/src/__tests__/directorySource.test.ts
+++ b/src/__tests__/directorySource.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
+const readRepositoryFile = (path: string) =>
+  readFileSync(new URL(path, `file://${repositoryRoot}/`), "utf8");
+
+describe("directory-facing source metadata", () => {
+  const readme = readRepositoryFile("README.md");
+  const server = JSON.parse(readRepositoryFile("server.json"));
+
+  it("links the canonical product contract and official MCP Registry record", () => {
+    expect(readme).toContain("https://api.oilpriceapi.com/product-facts.json");
+    expect(readme).toContain(
+      "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.OilpriceAPI%2Fmcp-server/versions/latest",
+    );
+  });
+
+  it("uses the direct account-creation route on directory-facing surfaces", () => {
+    expect(readme).not.toMatch(/oilpriceapi\.com\/signup(?:\?|\b)/i);
+
+    const apiKeyDescription = server.packages[0].environmentVariables.find(
+      (entry: { name: string }) => entry.name === "OILPRICEAPI_KEY",
+    ).description;
+    expect(apiKeyDescription).toContain("oilpriceapi.com/auth/signup");
+  });
+});


### PR DESCRIPTION
## Outcome

Makes the GitHub source consumed by Glama explicit and reviewable:

- links the keyless public product-facts contract
- links the exact active official MCP Registry record
- routes the remaining README and registry API-key references to /auth/signup
- adds a regression test for both canonical source links and direct account creation

Supports OilpriceAPI/website-clean#1365. MCP Market still requires a manual support update or paid resubmission; Glama ownership still requires GitHub OAuth.

## Verification

- Red first: 2/2 new tests failed before the source changes
- Full Vitest: 7 files, 165 tests passed
- Release metadata verified at 3.0.0
- TypeScript build passed; deterministic build metadata and 32-tool capability manifest generated
- Prettier passed for changed JSON/TypeScript; git diff check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added canonical links to public product information and the official MCP Registry record.
  * Updated the API key signup instructions to use the direct account-creation URL.

* **Tests**
  * Added coverage to verify documentation links and API key signup guidance remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->