### PR TITLE
Plan-tier labels in tool schemas + natural-gas hubs, account-status, and plans tools (#63, #64)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/anthropics/mcpb/main/dist/mcpb-manifest.schema.json",
   "manifest_version": "0.2",
   "name": "oilpriceapi",
-  "display_name": "OilPriceAPI — Oil, Gas & Commodity Prices",
-  "version": "3.0.0",
+  "display_name": "OilPriceAPI \u2014 Oil, Gas & Commodity Prices",
+  "version": "3.1.0",
   "description": "Source-timestamped energy data and reviewed OilPriceAPI product facts for MCP clients.",
   "long_description": "OilPriceAPI tools and resources for latest available energy values, history, futures, refining spreads, carrier fuel surcharges, selected energy-intelligence datasets, alerts, market briefs, and a versioned public product contract. Keyless demo mode supports a limited commodity set. Dataset access and limits vary by plan and account entitlement.",
   "author": {
@@ -13,7 +13,9 @@
   },
   "homepage": "https://oilpriceapi.com/mcp",
   "documentation": "https://github.com/OilpriceAPI/mcp-server#readme",
-  "privacy_policies": ["https://www.oilpriceapi.com/privacy"],
+  "privacy_policies": [
+    "https://www.oilpriceapi.com/privacy"
+  ],
   "support": "https://github.com/OilpriceAPI/mcp-server/issues",
   "icon": "icon.png",
   "server": {
@@ -21,7 +23,9 @@
     "entry_point": "build/index.js",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/build/index.js"],
+      "args": [
+        "${__dirname}/build/index.js"
+      ],
       "env": {
         "OILPRICEAPI_KEY": "${user_config.api_key}"
       }
@@ -31,7 +35,7 @@
     "api_key": {
       "type": "string",
       "title": "OilPriceAPI Key",
-      "description": "Optional — leave empty for the limited demo. Add an account key for the broader account-enabled catalog; dataset access varies by plan and entitlement.",
+      "description": "Optional \u2014 leave empty for the limited demo. Add an account key for the broader account-enabled catalog; dataset access varies by plan and entitlement.",
       "sensitive": true,
       "required": false
     }
@@ -54,7 +58,11 @@
     "url": "https://github.com/OilpriceAPI/mcp-server"
   },
   "compatibility": {
-    "platforms": ["darwin", "win32", "linux"],
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
     "runtimes": {
       "node": ">=18.0.0"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi-mcp",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "mcpName": "io.github.OilpriceAPI/mcp-server",
   "description": "Source-timestamped oil, gas, and related energy data plus reviewed product facts for MCP clients.",
   "type": "module",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -167,7 +167,7 @@ try {
   );
   if (
     readTools.scope !== "read" ||
-    readTools.tools.length !== 28 ||
+    readTools.tools.length !== 32 ||
     readTools.tools.some((tool) => tool.access === "write")
   ) {
     throw new Error(
@@ -275,8 +275,8 @@ try {
     throw new Error("Packaged doctor --demo did not pass.");
   }
 
-  await assertProtocolScope(entryPoint, baseUrl, "read", 28);
-  await assertProtocolScope(entryPoint, baseUrl, "write", 32);
+  await assertProtocolScope(entryPoint, baseUrl, "read", 32);
+  await assertProtocolScope(entryPoint, baseUrl, "write", 36);
 
   process.stdout.write(
     "packaged MCP smoke passed: version, configs, doctor, capabilities, scopes, and protocol blocking\n",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"
   },
-  "version": "3.0.0",
+  "version": "3.1.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "oilpriceapi-mcp",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1272,12 +1272,13 @@ describe("tool registration metadata", () => {
   const DELETE_TOOLS = ["opa_delete_price_alert", "opa_delete_subscription"];
   const WRITE_TOOLS = new Set([...CREATE_TOOLS, ...DELETE_TOOLS]);
 
-  it("registers exactly 35 tools", () => {
-    expect(Object.keys(tools)).toHaveLength(35);
+  it("registers exactly 36 tools", () => {
+    expect(Object.keys(tools)).toHaveLength(36);
     expect(tools.opa_get_product_facts).toBeDefined();
     expect(tools.opa_get_natural_gas_hubs).toBeDefined();
     expect(tools.opa_get_account_status).toBeDefined();
     expect(tools.opa_get_plans).toBeDefined();
+    expect(tools.opa_get_data_quality).toBeDefined();
   });
 
   // #63 — agents read schemas, not pricing pages: every plan-gated tool must
@@ -1297,6 +1298,7 @@ describe("tool registration metadata", () => {
     opa_get_well_permits: /well-permits add-on or an enterprise plan/,
     opa_get_well_production: /well-permits add-on or an enterprise plan/,
     opa_get_natural_gas_hubs: /Developer, \$19\/mo/,
+    opa_get_data_quality: /Developer, \$19\/mo/,
   };
 
   it("every plan-gated tool states its required plan in the description (#63)", () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1272,9 +1272,38 @@ describe("tool registration metadata", () => {
   const DELETE_TOOLS = ["opa_delete_price_alert", "opa_delete_subscription"];
   const WRITE_TOOLS = new Set([...CREATE_TOOLS, ...DELETE_TOOLS]);
 
-  it("registers exactly 32 tools", () => {
-    expect(Object.keys(tools)).toHaveLength(32);
+  it("registers exactly 35 tools", () => {
+    expect(Object.keys(tools)).toHaveLength(35);
     expect(tools.opa_get_product_facts).toBeDefined();
+    expect(tools.opa_get_natural_gas_hubs).toBeDefined();
+    expect(tools.opa_get_account_status).toBeDefined();
+    expect(tools.opa_get_plans).toBeDefined();
+  });
+
+  // #63 — agents read schemas, not pricing pages: every plan-gated tool must
+  // state its required plan in the description, so discovery does not cost 402s.
+  const GATED_TOOL_LABELS: Record<string, RegExp> = {
+    opa_get_history: /Developer, \$19\/mo/,
+    opa_get_futures: /Professional plan \(\$99\/mo\)/,
+    opa_get_futures_curve: /Professional plan \(\$99\/mo\)/,
+    opa_get_marine_fuels: /Professional plan \(\$99\/mo\)/,
+    opa_get_spread: /Professional plan \(\$99\/mo\)/,
+    opa_get_storage: /Reservoir Mastery/,
+    opa_get_rig_counts: /Reservoir Mastery/,
+    opa_get_opec_production: /Reservoir Mastery/,
+    opa_get_oil_inventories: /Reservoir Mastery/,
+    opa_get_forecasts: /Reservoir Mastery/,
+    opa_get_drilling: /Scale plan \(\$299\/mo\)/,
+    opa_get_well_permits: /well-permits add-on or an enterprise plan/,
+    opa_get_well_production: /well-permits add-on or an enterprise plan/,
+    opa_get_natural_gas_hubs: /Developer, \$19\/mo/,
+  };
+
+  it("every plan-gated tool states its required plan in the description (#63)", () => {
+    for (const [name, pattern] of Object.entries(GATED_TOOL_LABELS)) {
+      expect(tools[name], name).toBeDefined();
+      expect(tools[name].description, `${name} description`).toMatch(pattern);
+    }
   });
 
   it("registers all four write tools (creates + deletes)", () => {

--- a/src/__tests__/toolRegistry.test.ts
+++ b/src/__tests__/toolRegistry.test.ts
@@ -26,8 +26,8 @@ describe("MCP tool scope and profiles", () => {
     const registered = getRegisteredToolEntries(server);
 
     expect(configuration).toMatchObject({ scope: "read", profile: "all" });
-    expect(registered).toHaveLength(35);
-    expect(enabled).toHaveLength(31);
+    expect(registered).toHaveLength(36);
+    expect(enabled).toHaveLength(32);
     expect(enabled).toContain("opa_list_price_alerts");
     expect(enabled).toContain("opa_get_subscription_events");
     for (const name of WRITE_TOOL_NAMES) {
@@ -46,7 +46,7 @@ describe("MCP tool scope and profiles", () => {
     });
     const enabled = applyToolConfiguration(server, configuration);
 
-    expect(enabled).toHaveLength(35);
+    expect(enabled).toHaveLength(36);
     for (const name of WRITE_TOOL_NAMES) expect(enabled).toContain(name);
   });
 
@@ -118,7 +118,7 @@ describe("generated MCP capability manifest", () => {
       scope: "read",
       profile: "all",
     });
-    expect(first.tools).toHaveLength(35);
+    expect(first.tools).toHaveLength(36);
     expect(first.tools.map((tool) => tool.name).sort()).toEqual(
       getRegisteredToolEntries(server)
         .map(([name]) => name)
@@ -127,8 +127,8 @@ describe("generated MCP capability manifest", () => {
     expect(first.resources).toContainEqual(
       expect.objectContaining({ uri: "oilpriceapi://product-facts" }),
     );
-    expect(first.inventories.read.all).toHaveLength(31);
-    expect(first.inventories.write.all).toHaveLength(35);
+    expect(first.inventories.read.all).toHaveLength(32);
+    expect(first.inventories.write.all).toHaveLength(36);
   });
 
   it("contains no credential, account, prompt, or customer response data", () => {

--- a/src/__tests__/toolRegistry.test.ts
+++ b/src/__tests__/toolRegistry.test.ts
@@ -26,8 +26,8 @@ describe("MCP tool scope and profiles", () => {
     const registered = getRegisteredToolEntries(server);
 
     expect(configuration).toMatchObject({ scope: "read", profile: "all" });
-    expect(registered).toHaveLength(32);
-    expect(enabled).toHaveLength(28);
+    expect(registered).toHaveLength(35);
+    expect(enabled).toHaveLength(31);
     expect(enabled).toContain("opa_list_price_alerts");
     expect(enabled).toContain("opa_get_subscription_events");
     for (const name of WRITE_TOOL_NAMES) {
@@ -46,7 +46,7 @@ describe("MCP tool scope and profiles", () => {
     });
     const enabled = applyToolConfiguration(server, configuration);
 
-    expect(enabled).toHaveLength(32);
+    expect(enabled).toHaveLength(35);
     for (const name of WRITE_TOOL_NAMES) expect(enabled).toContain(name);
   });
 
@@ -58,7 +58,9 @@ describe("MCP tool scope and profiles", () => {
     );
     expect(core).toEqual([
       "opa_compare_prices",
+      "opa_get_account_status",
       "opa_get_history",
+      "opa_get_plans",
       "opa_get_price",
       "opa_get_product_facts",
       "opa_list_commodities",
@@ -116,7 +118,7 @@ describe("generated MCP capability manifest", () => {
       scope: "read",
       profile: "all",
     });
-    expect(first.tools).toHaveLength(32);
+    expect(first.tools).toHaveLength(35);
     expect(first.tools.map((tool) => tool.name).sort()).toEqual(
       getRegisteredToolEntries(server)
         .map(([name]) => name)
@@ -125,8 +127,8 @@ describe("generated MCP capability manifest", () => {
     expect(first.resources).toContainEqual(
       expect.objectContaining({ uri: "oilpriceapi://product-facts" }),
     );
-    expect(first.inventories.read.all).toHaveLength(28);
-    expect(first.inventories.write.all).toHaveLength(32);
+    expect(first.inventories.read.all).toHaveLength(31);
+    expect(first.inventories.write.all).toHaveLength(35);
   });
 
   it("contains no credential, account, prompt, or customer response data", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1116,7 +1116,7 @@ async function buildGateError(response: Response): Promise<ApiGateError> {
         : "Rate limit exceeded (HTTP 429) — the plan's request limit was hit";
   return new ApiGateError(
     response.status,
-    `${label}${detail ? `: ${detail}` : "."} Upgrade: ${UPGRADE_URL}`,
+    `${label}${detail ? `: ${detail}` : "."} Upgrade: ${UPGRADE_URL} — compare plans with the opa_get_plans tool; check current usage with opa_get_account_status.`,
   );
 }
 
@@ -1318,7 +1318,7 @@ export function alertHttpError(
   let msg = `Could not ${action} (HTTP ${result.status})${detail ? `: ${detail}` : "."}`;
   // Tier/feature gate or rate limit — add the upgrade nudge (#17).
   if (result.status === 402 || result.status === 403 || result.status === 429) {
-    msg += ` Upgrade: ${UPGRADE_URL}`;
+    msg += ` Upgrade: ${UPGRADE_URL} — compare plans with the opa_get_plans tool; check current usage with opa_get_account_status.`;
   }
   return msg;
 }
@@ -2231,7 +2231,7 @@ server.registerTool(
   {
     title: "Get Price History",
     description:
-      "Get historical price data for a commodity over a time period. Use when the user asks about price trends, historical prices, or how a commodity has performed over time. Returns high, low, average, change, and data point count. Periods: day (24h), week (7d), month (30d), year (365d).",
+      "Get historical price data for a commodity over a time period. Use when the user asks about price trends, historical prices, or how a commodity has performed over time. Returns high, low, average, change, and data point count. Periods: day (24h), week (7d), month (30d), year (365d). Requires a paid plan (Developer, $19/mo, and up) — the free tier serves latest prices only.",
     inputSchema: {
       commodity: z
         .string()
@@ -2303,7 +2303,7 @@ server.registerTool(
   {
     title: "Get Futures Price",
     description:
-      "Get the latest front-month futures contract price for energy commodities. Use when the user asks about futures, forward prices, or contract prices. Supports crude oil (BZ/ice-brent = Brent, CL/ice-wti = WTI), ICE Gasoil (ice-gasoil), natural gas (natural-gas), European TTF gas (ttf-gas), LNG JKM (lng-jkm), EUA carbon (eua-carbon), and UK carbon (uk-carbon). For the full forward curve across all contract months, use opa_get_futures_curve instead.",
+      "Get the latest front-month futures contract price for energy commodities. Use when the user asks about futures, forward prices, or contract prices. Supports crude oil (BZ/ice-brent = Brent, CL/ice-wti = WTI), ICE Gasoil (ice-gasoil), natural gas (natural-gas), European TTF gas (ttf-gas), LNG JKM (lng-jkm), EUA carbon (eua-carbon), and UK carbon (uk-carbon). For the full forward curve across all contract months, use opa_get_futures_curve instead. Requires the Professional plan ($99/mo) or higher.",
     inputSchema: {
       contract: z
         .enum(FUTURES_CONTRACTS)
@@ -2351,7 +2351,7 @@ server.registerTool(
   {
     title: "Get Futures Curve",
     description:
-      "Get the full futures forward curve showing prices across all contract months. Use when the user asks about the forward curve, contango/backwardation, or term structure. Supports crude oil (BZ/ice-brent = Brent, CL/ice-wti = WTI), ICE Gasoil (ice-gasoil), natural gas (natural-gas), European TTF gas (ttf-gas), LNG JKM (lng-jkm), EUA carbon (eua-carbon), and UK carbon (uk-carbon). Returns a table of contract months with settlement prices, plus market structure analysis.",
+      "Get the full futures forward curve showing prices across all contract months. Use when the user asks about the forward curve, contango/backwardation, or term structure. Supports crude oil (BZ/ice-brent = Brent, CL/ice-wti = WTI), ICE Gasoil (ice-gasoil), natural gas (natural-gas), European TTF gas (ttf-gas), LNG JKM (lng-jkm), EUA carbon (eua-carbon), and UK carbon (uk-carbon). Returns a table of contract months with settlement prices, plus market structure analysis. Requires the Professional plan ($99/mo) or higher.",
     inputSchema: {
       contract: z
         .enum(FUTURES_CONTRACTS)
@@ -2399,12 +2399,113 @@ server.registerTool(
   },
 );
 
+
+// ---------------------------------------------------------------------------
+// US physical natural gas hubs (#64) — wraps /v1/natural-gas/hubs (api#1294).
+// The API endpoint exists precisely because customers searched for hub codes
+// (Waha, SoCal Citygate, Algonquin...) and 404'd; this tool closes the same
+// discoverability gap on the MCP surface.
+// ---------------------------------------------------------------------------
+
+interface HubQuote {
+  hub: string;
+  name: string;
+  code: string;
+  region?: string;
+  price: number | null;
+  currency?: string;
+  unit?: string;
+  as_of?: string;
+  history_since?: string;
+  history_days?: number;
+  basis_to_henry?: number | null;
+  benchmark_price?: number | null;
+  basis_history?: Array<Record<string, unknown>>;
+}
+
+interface HubsIndexData {
+  benchmark: { code: string; name: string; price: number | null; as_of?: string };
+  hubs: HubQuote[];
+  meta?: Record<string, unknown>;
+}
+
+server.registerTool(
+  "opa_get_natural_gas_hubs",
+  {
+    title: "Get US Natural Gas Hub Prices",
+    description:
+      "Get US physical natural gas hub prices as basis to Henry Hub (USD/MMBtu). Use when the user asks about regional gas prices or hub basis — Waha (West Texas/Permian), SoCal Citygate, Chicago Citygate, Algonquin Citygate, Eastern Gas South (formerly Dominion South), Houston Ship Channel. Without a hub, returns every live hub plus its basis; with a hub, returns that hub's latest price, basis, and basis history. Hub series differ in depth — check history_days before requesting a long window. Requires a paid plan (Developer, $19/mo, and up).",
+    inputSchema: {
+      hub: z
+        .string()
+        .optional()
+        .describe(
+          "Optional hub slug: waha, socal, chicago, algonquin, eastern-gas-south, houston-ship-channel. Omit to list all live hubs with their basis to Henry Hub.",
+        ),
+      past: z
+        .string()
+        .optional()
+        .describe(
+          "Optional basis-history window for a single hub, e.g. 30d, 6m, 1y (only used when hub is given).",
+        ),
+    },
+    annotations: READ_TOOL_ANNOTATIONS,
+  },
+  async ({ hub, past }) => {
+    if (!getApiKey()) return keylessTeaserResult("opa_get_natural_gas_hubs");
+
+    if (hub) {
+      const query = past ? `?past=${encodeURIComponent(past)}` : "";
+      const response = await makeApiRequest<ApiResponse<HubQuote>>(
+        `/v1/natural-gas/hubs/${encodeURIComponent(hub.toLowerCase())}${query}`,
+      );
+      if (!response || response.status !== "success") {
+        return errorResult(
+          `No data for natural gas hub '${hub}'. Valid slugs: waha, socal, chicago, algonquin, eastern-gas-south, houston-ship-channel. Requires a paid plan (Developer $19/mo and up).`,
+        );
+      }
+      const q = response.data;
+      let text = `# ${q.name ?? hub} Natural Gas\n\n`;
+      text += "```json\n" + JSON.stringify(q, null, 2) + "\n```\n";
+      text +=
+        "\n_basis_to_henry = hub price − Henry Hub price on the same gas day (USD/MMBtu) | Data from [OilPriceAPI](https://oilpriceapi.com)_";
+      return textResult(text);
+    }
+
+    const response = await makeApiRequest<ApiResponse<HubsIndexData>>(
+      "/v1/natural-gas/hubs",
+    );
+    if (!response || response.status !== "success") {
+      return errorResult(
+        "Natural gas hub data not available. Requires a paid plan (Developer $19/mo and up).",
+      );
+    }
+    const { benchmark, hubs } = response.data;
+    let text = "# US Natural Gas Hubs — Basis to Henry Hub\n\n";
+    if (benchmark) {
+      text += `Benchmark: **${benchmark.name}** ${benchmark.price != null ? `$${benchmark.price}` : "n/a"}${benchmark.as_of ? ` (as of ${benchmark.as_of})` : ""}\n\n`;
+    }
+    text += "| Hub | Price | Basis | History since |\n|---|---|---|---|\n";
+    for (const h of hubs ?? []) {
+      const price = h.price != null ? `$${h.price}` : "n/a";
+      const basis =
+        h.basis_to_henry != null
+          ? `${h.basis_to_henry >= 0 ? "+" : ""}${h.basis_to_henry}`
+          : "n/a";
+      text += `| ${h.name} (${h.hub}) | ${price} | ${basis} | ${h.history_since ?? "?"} (${h.history_days ?? "?"}d) |\n`;
+    }
+    text +=
+      "\n_USD/MMBtu; basis = hub − Henry Hub, same gas day. Hub histories differ in depth — check history_days. | Data from [OilPriceAPI](https://oilpriceapi.com)_";
+    return textResult(text);
+  },
+);
+
 server.registerTool(
   "opa_get_marine_fuels",
   {
     title: "Get Marine Fuel Prices",
     description:
-      "Get latest marine fuel (bunker) prices across major shipping ports. Use when the user asks about bunker fuel, marine fuel, VLSFO, MGO, IFO380, or shipping fuel costs. Can filter by port (e.g., SINGAPORE, ROTTERDAM, HOUSTON) and/or fuel type (VLSFO, MGO, IFO380). Returns a table of port prices.",
+      "Get latest marine fuel (bunker) prices across major shipping ports. Use when the user asks about bunker fuel, marine fuel, VLSFO, MGO, IFO380, or shipping fuel costs. Can filter by port (e.g., SINGAPORE, ROTTERDAM, HOUSTON) and/or fuel type (VLSFO, MGO, IFO380). Returns a table of port prices. Requires the Professional plan ($99/mo) or higher.",
     inputSchema: {
       port: z
         .string()
@@ -2461,7 +2562,7 @@ server.registerTool(
   {
     title: "Get US Rig Counts",
     description:
-      "Get the latest US oil and gas rig count data (Baker Hughes). Use when the user asks about drilling activity, rig counts, or oil field operations. Returns oil rigs, gas rigs, total count, and week-over-week change. No parameters needed.",
+      "Get the latest US oil and gas rig count data (Baker Hughes). Use when the user asks about drilling activity, rig counts, or oil field operations. Returns oil rigs, gas rigs, total count, and week-over-week change. No parameters needed. Requires the Reservoir Mastery premium tier.",
     inputSchema: {},
     annotations: READ_TOOL_ANNOTATIONS,
   },
@@ -2555,7 +2656,7 @@ server.registerTool(
   {
     title: "Get Drilling Activity",
     description:
-      "Get a drilling activity snapshot: US, Canada, and international rig counts, frac spread count, well permits issued in the last 30 days (with a by-state breakdown), and DUC (drilled-uncompleted) well totals. Use when the user asks about drilling activity, rigs vs frac spreads, or upstream operations. Requires a paid plan with energy intelligence access.",
+      "Get a drilling activity snapshot: US, Canada, and international rig counts, frac spread count, well permits issued in the last 30 days (with a by-state breakdown), and DUC (drilled-uncompleted) well totals. Use when the user asks about drilling activity, rigs vs frac spreads, or upstream operations. Requires the Scale plan ($299/mo) or a drilling data plan.",
     inputSchema: {},
     annotations: READ_TOOL_ANNOTATIONS,
   },
@@ -2714,7 +2815,7 @@ server.registerTool(
   {
     title: "Get Oil Storage Levels",
     description:
-      "Get oil storage and inventory levels for Cushing, Oklahoma (WTI delivery hub) and/or the US Strategic Petroleum Reserve (SPR). Use when the user asks about oil inventories, storage levels, Cushing stocks, or the SPR. Returns current inventory levels with changes.",
+      "Get oil storage and inventory levels for Cushing, Oklahoma (WTI delivery hub) and/or the US Strategic Petroleum Reserve (SPR). Use when the user asks about oil inventories, storage levels, Cushing stocks, or the SPR. Returns current inventory levels with changes. Requires the Reservoir Mastery premium tier.",
     inputSchema: {
       facility: z
         .enum(["cushing", "spr", "all"])
@@ -2774,7 +2875,7 @@ server.registerTool(
   {
     title: "Get OPEC Production",
     description:
-      "Get the latest OPEC oil production data. Use when the user asks about OPEC output, production quotas, supply cuts, or OPEC+ compliance. Returns country-level production figures. Requires a paid plan with energy intelligence access.",
+      "Get the latest OPEC oil production data. Use when the user asks about OPEC output, production quotas, supply cuts, or OPEC+ compliance. Returns country-level production figures. Requires the Reservoir Mastery premium tier.",
     inputSchema: {},
     annotations: READ_TOOL_ANNOTATIONS,
   },
@@ -2804,7 +2905,7 @@ server.registerTool(
   {
     title: "Get Price Forecasts",
     description:
-      "Get energy price forecasts from EIA Short-Term Energy Outlook (STEO) and other sources. Use when the user asks about price predictions, outlooks, or where oil/gas prices are heading. Returns forecast data for key commodities. Requires a paid plan with energy intelligence access.",
+      "Get energy price forecasts from EIA Short-Term Energy Outlook (STEO) and other sources. Use when the user asks about price predictions, outlooks, or where oil/gas prices are heading. Returns forecast data for key commodities. Requires the Reservoir Mastery premium tier.",
     inputSchema: {},
     annotations: READ_TOOL_ANNOTATIONS,
   },
@@ -2839,7 +2940,7 @@ server.registerTool(
   {
     title: "Get EIA Oil Inventories",
     description:
-      "Get the latest EIA weekly petroleum inventory (stocks) data. Use when the user asks about oil inventories, crude stocks, weekly EIA stocks, inventory builds/draws, or product-level inventory levels. Returns the latest weekly figures; optionally a summary view or a breakdown by petroleum product. Requires a paid plan with energy intelligence access.",
+      "Get the latest EIA weekly petroleum inventory (stocks) data. Use when the user asks about oil inventories, crude stocks, weekly EIA stocks, inventory builds/draws, or product-level inventory levels. Returns the latest weekly figures; optionally a summary view or a breakdown by petroleum product. Requires the Reservoir Mastery premium tier.",
     inputSchema: {
       view: z
         .enum(["latest", "summary", "by_product"])
@@ -2883,7 +2984,7 @@ server.registerTool(
   {
     title: "Get Well Permits",
     description:
-      "Get the latest US oil & gas well drilling permit data. Use when the user asks about well permits, new drilling permits, permitting activity, or upstream permit trends. Returns the latest permits; optionally filtered/aggregated by state or by operator. Requires a paid plan with energy intelligence access.",
+      "Get the latest US oil & gas well drilling permit data. Use when the user asks about well permits, new drilling permits, permitting activity, or upstream permit trends. Returns the latest permits; optionally filtered/aggregated by state or by operator. Requires the well-permits add-on or an enterprise plan.",
     inputSchema: {
       view: z
         .enum(["latest", "by_state", "by_operator"])
@@ -3591,7 +3692,7 @@ server.registerTool(
   {
     title: "Get Well Production",
     description:
-      "Get US oil & gas well production data (BETA coverage: monthly state-level production from EIA + selected state regulators, and well-level histories for selected states only — NOT complete US well-level production). Views: summary (national + top states), states (all reporting states, latest month), state (monthly history for one state), well (monthly history for one well by 14-digit API number), top_producers (highest-output wells, optionally by state), cycle_time (permit-to-production cycle time stats, optionally by state), cohorts (cycle times by spud quarter). Use when the user asks about oil/gas production volumes by state or well, top producing wells, or drill-to-production cycle times. Requires a paid plan with energy intelligence access.",
+      "Get US oil & gas well production data (BETA coverage: monthly state-level production from EIA + selected state regulators, and well-level histories for selected states only — NOT complete US well-level production). Views: summary (national + top states), states (all reporting states, latest month), state (monthly history for one state), well (monthly history for one well by 14-digit API number), top_producers (highest-output wells, optionally by state), cycle_time (permit-to-production cycle time stats, optionally by state), cohorts (cycle times by spud quarter). Use when the user asks about oil/gas production volumes by state or well, top producing wells, or drill-to-production cycle times. Requires the well-permits add-on or an enterprise plan.",
     inputSchema: {
       view: z
         .enum(WELL_PRODUCTION_VIEWS)
@@ -3649,7 +3750,7 @@ server.registerTool(
   {
     title: "Get Refining & Trading Spreads",
     description:
-      "Get refining and trading spreads: crack spreads (refining margin proxy), basis spreads (regional price differentials), and blending/transport margins. Use when the user asks about crack spreads, 3-2-1 crack, refining margins, basis differentials, or blend/transport margins. Requires a paid plan with energy intelligence access.",
+      "Get refining and trading spreads: crack spreads (refining margin proxy), basis spreads (regional price differentials), and blending/transport margins. Use when the user asks about crack spreads, 3-2-1 crack, refining margins, basis differentials, or blend/transport margins. Requires the Professional plan ($99/mo) or higher.",
     inputSchema: {
       type: z
         .enum(["crack", "basis", "margin"])
@@ -3720,6 +3821,109 @@ function formatAlertLine(a: AlertRecord): string {
     : "";
   return `- **${a.name || label}** (id: \`${a.id}\`) — ${label} [${status}${triggers}${last}]`;
 }
+
+
+// ---------------------------------------------------------------------------
+// Agent self-service (#63 follow-through): let an agent answer "what plan am I
+// on, what is left, and what would an upgrade cost" WITHOUT probing gated
+// tools. Status reads the authenticated /v1/dashboard; plans reads the public
+// /v1/pricing (live source of truth — prices are never hardcoded here).
+// ---------------------------------------------------------------------------
+
+interface DashboardUsage {
+  current_month?: {
+    used?: number;
+    limit?: number;
+    effective_limit?: number;
+    remaining?: number;
+    percentage_used?: number;
+    reset_at?: string;
+    usage_window?: string;
+  };
+  subscription_tier?: string;
+}
+
+interface DashboardData {
+  usage?: DashboardUsage;
+  user?: { email?: string; created_at?: string };
+  feature_access?: Record<string, unknown> | null;
+}
+
+server.registerTool(
+  "opa_get_account_status",
+  {
+    title: "Get Account Status",
+    description:
+      "Get the current API account's plan tier, request usage, remaining quota, and reset date. Use before calling gated tools, when the user asks about their plan/limits/usage, or after any 402/403/429 to explain what the current plan covers. Works on every plan including free.",
+    inputSchema: {},
+    annotations: READ_TOOL_ANNOTATIONS,
+  },
+  async () => {
+    if (!getApiKey()) return keylessTeaserResult("opa_get_account_status");
+
+    const response =
+      await makeApiRequest<ApiResponse<DashboardData>>("/v1/dashboard");
+    if (!response || response.status !== "success") {
+      return errorResult(
+        "Could not read account status. If this persists, verify the OILPRICEAPI_KEY is valid.",
+      );
+    }
+    const usage = response.data.usage ?? {};
+    const month = usage.current_month ?? {};
+    const tier = usage.subscription_tier ?? "free";
+    let text = "# OilPriceAPI Account Status\n\n";
+    text += `- **Plan tier:** ${tier}\n`;
+    if (month.limit != null) {
+      text += `- **Requests this period:** ${month.used ?? 0} of ${month.effective_limit ?? month.limit} (${month.percentage_used ?? 0}% used, ${month.remaining ?? "?"} remaining)\n`;
+    }
+    if (month.reset_at) text += `- **Quota resets:** ${month.reset_at}\n`;
+    text +=
+      "\nTo see what higher plans include, call opa_get_plans. Gated tools state their required plan in their descriptions.";
+    return textResult(text);
+  },
+);
+
+interface PricingPlan {
+  id?: string;
+  name?: string;
+  monthlyPrice?: number;
+  yearlyPrice?: number;
+  requestLimit?: number;
+  features?: string[];
+  popular?: boolean;
+}
+
+server.registerTool(
+  "opa_get_plans",
+  {
+    title: "Get Plans & Pricing",
+    description:
+      "Get OilPriceAPI's current subscription plans: monthly/yearly price, request limits, and included features for each tier. Use when the user asks what an upgrade costs, which plan unlocks a gated tool (history, futures, natural gas hubs...), or how the tiers compare. Live pricing from the API — no key required.",
+    inputSchema: {},
+    annotations: READ_TOOL_ANNOTATIONS,
+  },
+  async () => {
+    const response = await makeApiRequest<
+      ApiResponse<{ plans?: PricingPlan[] }>
+    >("/v1/pricing");
+    const plans = response?.data?.plans;
+    if (!response || response.status !== "success" || !plans?.length) {
+      return errorResult(
+        `Could not load live plan data. Current plans are listed at ${UPGRADE_URL}`,
+      );
+    }
+    let text = "# OilPriceAPI Plans\n\n";
+    text += "| Plan | Monthly | Yearly | Requests/mo | Key features |\n";
+    text += "|---|---|---|---|---|\n";
+    for (const p of plans) {
+      const feats = (p.features ?? []).slice(0, 4).join("; ");
+      text += `| ${p.name}${p.popular ? " ★" : ""} | $${p.monthlyPrice} | $${p.yearlyPrice} | ${p.requestLimit?.toLocaleString?.() ?? p.requestLimit} | ${feats} |\n`;
+    }
+    text += `\nFree tier: 200 requests/mo, latest prices only.\n`;
+    text += `\nTo subscribe or upgrade, open: ${UPGRADE_URL} (checkout takes ~1 minute). Check the current plan with opa_get_account_status.`;
+    return textResult(text);
+  },
+);
 
 server.registerTool(
   "opa_create_price_alert",

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export {
 // API Configuration
 const API_BASE =
   process.env.OILPRICEAPI_BASE_URL || "https://api.oilpriceapi.com";
-export const MCP_VERSION = "3.0.0";
+export const MCP_VERSION = "3.1.0";
 export const CLIENT_MARKER = `oilpriceapi-mcp/${MCP_VERSION}`;
 export const USER_AGENT = CLIENT_MARKER;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3925,6 +3925,66 @@ server.registerTool(
   },
 );
 
+
+// ---------------------------------------------------------------------------
+// Data-quality reports — wraps /v1/data-quality/{summary,reports/:code}.
+// Provenance surface: per-series grades and dimension scores, so an agent can
+// answer "how reliable is the series I am about to depend on" from the API
+// itself. Catalogue summary is available on any key; per-commodity reports are
+// paid (require_paid_subscription in data_quality_reports_controller).
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "opa_get_data_quality",
+  {
+    title: "Get Data Quality Report",
+    description:
+      "Get OilPriceAPI's own data-quality grades. With a commodity code: that series' quality report — overall grade/score plus dimension scores (completeness, freshness, and more) for the current period. Without a code: the catalogue-wide summary (grade distribution by category). Use when the user asks how reliable/complete a series is, or which series carry the highest quality grades. Per-commodity reports require a paid plan (Developer, $19/mo, and up); the summary works on any key.",
+    inputSchema: {
+      commodity: z
+        .string()
+        .optional()
+        .describe(
+          "Optional commodity name or code (e.g., 'brent', 'NATURAL_GAS_USD') for a per-series report. Omit for the catalogue-wide summary.",
+        ),
+    },
+    annotations: READ_TOOL_ANNOTATIONS,
+  },
+  async ({ commodity }) => {
+    if (!getApiKey()) return keylessTeaserResult("opa_get_data_quality");
+
+    if (commodity) {
+      const resolved = resolveOrError(commodity);
+      if ("error" in resolved) return resolved.error;
+      const response = await makeApiRequest<
+        ApiResponse<{ report?: Record<string, unknown> }>
+      >(`/v1/data-quality/reports/${encodeURIComponent(resolved.code)}`);
+      if (!response || response.status !== "success" || !response.data.report) {
+        return errorResult(
+          `No data-quality report for '${commodity}' (code: ${resolved.code}). Per-commodity reports require a paid plan (Developer $19/mo and up).`,
+        );
+      }
+      let text = `# Data Quality — ${resolved.code}\n\n`;
+      text += "```json\n" + JSON.stringify(response.data.report, null, 2) + "\n```\n";
+      text +=
+        "\n_Grades are computed per period from measured completeness/freshness — not marketing copy. | [OilPriceAPI](https://oilpriceapi.com)_";
+      return textResult(text);
+    }
+
+    const response = await makeApiRequest<
+      ApiResponse<{ summary?: Record<string, unknown> }>
+    >("/v1/data-quality/summary");
+    if (!response || response.status !== "success" || !response.data.summary) {
+      return errorResult("Data-quality summary not available right now.");
+    }
+    let text = "# OilPriceAPI Data Quality — Catalogue Summary\n\n";
+    text += "```json\n" + JSON.stringify(response.data.summary, null, 2) + "\n```\n";
+    text +=
+      "\n_Per-commodity reports: call this tool with a commodity code (paid plans). | [OilPriceAPI](https://oilpriceapi.com)_";
+    return textResult(text);
+  },
+);
+
 server.registerTool(
   "opa_create_price_alert",
   {

--- a/src/toolRegistry.ts
+++ b/src/toolRegistry.ts
@@ -31,9 +31,12 @@ const TOOL_CATEGORY_BY_NAME: Record<string, ToolCategory> = {
   opa_compare_prices: "core",
   opa_list_commodities: "core",
   opa_get_history: "core",
+  opa_get_account_status: "core",
+  opa_get_plans: "core",
   opa_get_futures: "market",
   opa_get_futures_curve: "market",
   opa_get_marine_fuels: "market",
+  opa_get_natural_gas_hubs: "market",
   opa_get_rig_counts: "market",
   opa_get_drilling: "market",
   opa_get_diesel_by_state: "market",
@@ -61,6 +64,7 @@ const TOOL_CATEGORY_BY_NAME: Record<string, ToolCategory> = {
 
 const KEYLESS_TOOLS = new Set([
   "opa_get_product_facts",
+  "opa_get_plans",
   "opa_get_price",
   "opa_market_overview",
   "opa_compare_prices",

--- a/src/toolRegistry.ts
+++ b/src/toolRegistry.ts
@@ -52,6 +52,7 @@ const TOOL_CATEGORY_BY_NAME: Record<string, ToolCategory> = {
   opa_get_well_production: "market",
   opa_get_spread: "market",
   opa_get_market_brief: "market",
+  opa_get_data_quality: "market",
   opa_create_price_alert: "automation",
   opa_list_price_alerts: "automation",
   opa_delete_price_alert: "automation",


### PR DESCRIPTION
## What

Four upgrades that let an agent answer "can I call this, what do I have left, and what would more cost" from the schema instead of by probing:

1. **Tier labels in every gated tool description (#63)** — verified against the API's `User::TIER_FEATURES` and controller gates on 2026-08-09: history → Developer $19+; futures/curve/marine/spreads → Professional $99+; storage/rigs/OPEC/inventories/forecasts → Reservoir Mastery; drilling → Scale $299; well permits → add-on/enterprise; hubs → Developer $19+.
2. **`opa_get_natural_gas_hubs` (#64)** — wraps `GET /v1/natural-gas/hubs[/:hub]` (api#1294). Lists 6 live hubs with basis to Henry Hub and per-hub `history_days`.
3. **`opa_get_account_status`** — plan tier, used/limit/remaining, reset date via `/v1/dashboard` (plain Token auth, verified live).
4. **`opa_get_plans`** — live ladder from public `/v1/pricing`; keyless-enabled so demo agents can see the upgrade path. Gate errors (#17) now reference both new tools.

## Why

Measured on prod (30d): 24 of 31 MCP accounts widen to 2+ endpoints; 11 of their 94 account-endpoint pairs were 402/403-only — agents discovering the paywall by trial. Customer interview (cairns.ap@gmail.com, 2026-08-08) described the mechanism and proposed the schema fix verbatim. Full data: api#3898 comment.

## Verification

- `vitest run`: 166/166 pass (new test asserts every gated tool's description matches its tier label)
- `npm run build`: capability manifest regenerates with 35 tools
- `scripts/live-smoke.mjs` against production: PASSED
- Backends hit live with a real key on 2026-08-09: `/v1/dashboard`, `/v1/pricing`, `/v1/natural-gas/hubs` (+ single-hub)

Post-publish assertion (per #63): gate-only share of MCP widening in `api_requests` should trend toward 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added natural gas hub lookups, including individual hubs, all-hub listings, Henry Hub basis data, and optional history.
  - Added account status reporting for plan usage and quota information.
  - Added plan and pricing information, available without an API key.
- **Improvements**
  - Tool descriptions now clearly identify plan and add-on requirements.
  - Tier-limit messages now link to plan details and account status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->