### PR TITLE
as_of point-in-time (vintage) param on opa_get_history (v3.2.0)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.2",
   "name": "oilpriceapi",
   "display_name": "OilPriceAPI \u2014 Oil, Gas & Commodity Prices",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Source-timestamped energy data and reviewed OilPriceAPI product facts for MCP clients.",
   "long_description": "OilPriceAPI tools and resources for latest available energy values, history, futures, refining spreads, carrier fuel surcharges, selected energy-intelligence datasets, alerts, market briefs, and a versioned public product contract. Keyless demo mode supports a limited commodity set. Dataset access and limits vary by plan and account entitlement.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi-mcp",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "mcpName": "io.github.OilpriceAPI/mcp-server",
   "description": "Source-timestamped oil, gas, and related energy data plus reviewed product facts for MCP clients.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"
   },
-  "version": "3.1.0",
+  "version": "3.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "oilpriceapi-mcp",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export {
 // API Configuration
 const API_BASE =
   process.env.OILPRICEAPI_BASE_URL || "https://api.oilpriceapi.com";
-export const MCP_VERSION = "3.1.0";
+export const MCP_VERSION = "3.2.0";
 export const CLIENT_MARKER = `oilpriceapi-mcp/${MCP_VERSION}`;
 export const USER_AGENT = CLIENT_MARKER;
 
@@ -2231,7 +2231,7 @@ server.registerTool(
   {
     title: "Get Price History",
     description:
-      "Get historical price data for a commodity over a time period. Use when the user asks about price trends, historical prices, or how a commodity has performed over time. Returns high, low, average, change, and data point count. Periods: day (24h), week (7d), month (30d), year (365d). Requires a paid plan (Developer, $19/mo, and up) — the free tier serves latest prices only.",
+      "Get historical price data for a commodity over a time period. Use when the user asks about price trends, historical prices, or how a commodity has performed over time. Returns high, low, average, change, and data point count. Periods: day (24h), week (7d), month (30d), year (365d). Supports point-in-time (vintage) queries via as_of: the series as it was knowable at that instant — later-collected rows absent, later revisions rolled back (no lookahead bias; built for backtests). Requires a paid plan (Developer, $19/mo, and up) — the free tier serves latest prices only.",
     inputSchema: {
       commodity: z
         .string()
@@ -2240,17 +2240,24 @@ server.registerTool(
         .enum(["day", "week", "month", "year"])
         .default("month")
         .describe("Time period: day, week, month, or year (default: month)"),
+      as_of: z
+        .string()
+        .optional()
+        .describe(
+          "Optional ISO8601 date/datetime for a point-in-time (vintage) view, e.g. '2026-06-02'. Returns the series as it was knowable then: rows collected later are absent and values revised later are rolled back. Must not be in the future. Revision-correction coverage since 2026-07-28.",
+        ),
     },
     annotations: READ_TOOL_ANNOTATIONS,
   },
-  async ({ commodity, period }) => {
+  async ({ commodity, period, as_of }) => {
     if (!getApiKey()) return keylessTeaserResult("opa_get_history");
 
     const resolved = resolveOrError(commodity);
     if ("error" in resolved) return resolved.error;
 
+    const asOfQuery = as_of ? `&as_of=${encodeURIComponent(as_of)}` : "";
     const response = await makeApiRequest<ApiResponse<HistoricalPriceData>>(
-      `/v1/prices/past_${period}?by_code=${resolved.code}`,
+      `/v1/prices/past_${period}?by_code=${resolved.code}${asOfQuery}`,
     );
 
     if (


### PR DESCRIPTION
Pairs with oilpriceapi-api#6428 (#6405 Phase 1). Schema documents the vintage semantics so agents discover it without probing. 166 tests green. **Do not publish to npm until the API change is deployed and live-verified** — against an older server the param would be silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)