### PR TITLE
Recover npm publication with typed registry state

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -186,15 +186,21 @@ jobs:
           NAME=$(tar -xOf "$PACKAGE_FILE" package/package.json | jq -er '.name')
           VERSION=$(tar -xOf "$PACKAGE_FILE" package/package.json | jq -er '.version')
           SOURCE_COMMIT=$(tar -xOf "$PACKAGE_FILE" package/build/build-metadata.json | jq -er '.sourceCommit | select(test("^[0-9a-f]{40}$"))')
-          EXISTING_INTEGRITY=$(timeout 30s node "$NPM_CLI" view "$NAME@$VERSION" dist.integrity --json 2>/dev/null | jq -r '. // empty' || true)
-          if [ -n "$EXISTING_INTEGRITY" ]; then
-            if [ "$EXISTING_INTEGRITY" != "$EXPECTED_INTEGRITY" ]; then
-              echo "::error::npm $NAME@$VERSION exists with unexpected integrity"
-              exit 1
-            fi
+          PUBLICATION_STATE=$(
+            NPM_RELEASE_MODE=publication-state \
+            NPM_RELEASE_EXPECTED_NAME="$NAME" \
+            NPM_RELEASE_EXPECTED_VERSION="$VERSION" \
+            NPM_RELEASE_EXPECTED_INTEGRITY="$EXPECTED_INTEGRITY" \
+            NPM_RELEASE_TIMEOUT_MS=10000 \
+              timeout 30s node verify-npm-release.mjs
+          )
+          if [ "$PUBLICATION_STATE" = "present" ]; then
             echo "npm $NAME@$VERSION already matches the verified tarball; continuing recovery."
-          else
+          elif [ "$PUBLICATION_STATE" = "absent" ]; then
             timeout 10m node "$NPM_CLI" publish "$PACKAGE_FILE" --ignore-scripts --provenance --access public
+          else
+            echo "::error::Unexpected npm publication state: $PUBLICATION_STATE"
+            exit 1
           fi
 
           NPM_RELEASE_EXPECTED_NAME="$NAME" \

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,11 +1,11 @@
 {
   "name": "oilpriceapi",
   "description": "Source-timestamped energy data and reviewed OilPriceAPI product facts for MCP clients.",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "mcpServers": {
     "oilpriceapi": {
       "command": "npx",
-      "args": ["-y", "oilpriceapi-mcp@3.2.1"]
+      "args": ["-y", "oilpriceapi-mcp@3.2.2"]
     }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.2",
   "name": "oilpriceapi",
   "display_name": "OilPriceAPI \u2014 Oil, Gas & Commodity Prices",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Source-timestamped energy data and reviewed OilPriceAPI product facts for MCP clients.",
   "long_description": "OilPriceAPI tools and resources for latest available energy values, history, futures, refining spreads, carrier fuel surcharges, selected energy-intelligence datasets, alerts, market briefs, and a versioned public product contract. Keyless demo mode supports a limited commodity set. Dataset access and limits vary by plan and account entitlement.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi-mcp",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi-mcp",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "mcpName": "io.github.OilpriceAPI/mcp-server",
   "description": "Source-timestamped oil, gas, and related energy data plus reviewed product facts for MCP clients.",
   "type": "module",

--- a/scripts/verify-npm-release-smoke.mjs
+++ b/scripts/verify-npm-release-smoke.mjs
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  resolveNpmPublicationState,
   validateNpmAttestationsDocument,
   validateNpmVersionDocument,
   verifyNpmRelease,
@@ -102,6 +103,56 @@ function attestationsDocument(statement = validStatement()) {
 
 validateNpmVersionDocument(validVersion, expected);
 validateNpmAttestationsDocument(attestationsDocument(), expected);
+
+function registryResponse(status, payload) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  };
+}
+
+const absentState = await resolveNpmPublicationState({
+  ...expected,
+  fetchImpl: async () => registryResponse(404, { error: "Not found" }),
+});
+if (absentState !== "absent") {
+  throw new Error("npm publication-state verifier did not accept an exact 404");
+}
+
+const presentState = await resolveNpmPublicationState({
+  ...expected,
+  fetchImpl: async () => registryResponse(200, validVersion),
+});
+if (presentState !== "present") {
+  throw new Error(
+    "npm publication-state verifier did not recognize the exact tarball",
+  );
+}
+
+for (const response of [
+  registryResponse(200, {
+    ...validVersion,
+    dist: { ...validVersion.dist, integrity: "sha512-wrong" },
+  }),
+  registryResponse(200, { error: "not a version document" }),
+  registryResponse(500, { error: "registry unavailable" }),
+]) {
+  let rejected = false;
+  try {
+    await resolveNpmPublicationState({
+      ...expected,
+      fetchImpl: async () => response,
+    });
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) {
+    throw new Error(
+      "npm publication-state verifier accepted an ambiguous registry response",
+    );
+  }
+}
 
 for (const mutate of [
   (document) => {

--- a/scripts/verify-npm-release.mjs
+++ b/scripts/verify-npm-release.mjs
@@ -64,6 +64,61 @@ export function validateNpmVersionDocument(
   }
 }
 
+export async function resolveNpmPublicationState({
+  expectedName,
+  expectedVersion,
+  expectedIntegrity,
+  timeoutMs = 10_000,
+  fetchImpl = fetch,
+}) {
+  if (
+    typeof expectedName !== "string" ||
+    expectedName.length === 0 ||
+    typeof expectedVersion !== "string" ||
+    expectedVersion.length === 0
+  ) {
+    throw new Error("expected npm package name and version are required");
+  }
+  integrityHex(expectedIntegrity);
+
+  const encodedName = encodeURIComponent(expectedName);
+  const encodedVersion = encodeURIComponent(expectedVersion);
+  const response = await fetchImpl(
+    `${REGISTRY_BASE}/${encodedName}/${encodedVersion}`,
+    {
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+      signal: AbortSignal.timeout(timeoutMs),
+    },
+  );
+
+  if (response.status === 404) return "absent";
+  if (!response.ok) {
+    throw new Error(
+      `npm publication-state readback returned HTTP ${response.status}`,
+    );
+  }
+
+  const document = requireRecord(
+    await response.json(),
+    "npm publication-state document",
+  );
+  const dist = requireRecord(
+    document.dist,
+    "npm publication-state dist metadata",
+  );
+  if (
+    document.name !== expectedName ||
+    document.version !== expectedVersion ||
+    dist.integrity !== expectedIntegrity
+  ) {
+    throw new Error(
+      "npm publication-state metadata did not match the verified tarball",
+    );
+  }
+  return "present";
+}
+
 export function validateNpmAttestationsDocument(
   value,
   {
@@ -257,38 +312,58 @@ if (
   const expectedVersion = process.env.NPM_RELEASE_EXPECTED_VERSION;
   const expectedIntegrity = process.env.NPM_RELEASE_EXPECTED_INTEGRITY;
   const expectedSourceCommit = process.env.NPM_RELEASE_EXPECTED_SOURCE_COMMIT;
+  const mode = process.env.NPM_RELEASE_MODE || "verify";
   if (
     !expectedName ||
     !expectedVersion ||
-    !expectedIntegrity ||
-    !/^[0-9a-f]{40}$/.test(expectedSourceCommit || "")
+    !expectedIntegrity
   ) {
     throw new Error(
-      "NPM_RELEASE_EXPECTED_NAME, NPM_RELEASE_EXPECTED_VERSION, NPM_RELEASE_EXPECTED_INTEGRITY, and a 40-character NPM_RELEASE_EXPECTED_SOURCE_COMMIT are required",
+      "NPM_RELEASE_EXPECTED_NAME, NPM_RELEASE_EXPECTED_VERSION, and NPM_RELEASE_EXPECTED_INTEGRITY are required",
     );
   }
-  const attempts = Number(process.env.NPM_RELEASE_ATTEMPTS || 12);
-  const delayMs = Number(process.env.NPM_RELEASE_DELAY_MS || 5_000);
   const timeoutMs = Number(process.env.NPM_RELEASE_TIMEOUT_MS || 10_000);
-  if (!Number.isInteger(attempts) || attempts < 1) {
-    throw new Error("NPM_RELEASE_ATTEMPTS must be a positive integer");
-  }
-  if (!Number.isInteger(delayMs) || delayMs < 0) {
-    throw new Error("NPM_RELEASE_DELAY_MS must be a non-negative integer");
-  }
   if (!Number.isInteger(timeoutMs) || timeoutMs < 1) {
     throw new Error("NPM_RELEASE_TIMEOUT_MS must be a positive integer");
   }
-  await verifyNpmRelease({
-    expectedName,
-    expectedVersion,
-    expectedIntegrity,
-    expectedSourceCommit,
-    attempts,
-    delayMs,
-    timeoutMs,
-  });
-  process.stdout.write(
-    `npm latest integrity and source-bound SLSA provenance verified for ${expectedName}@${expectedVersion}.\n`,
-  );
+
+  if (mode === "publication-state") {
+    const state = await resolveNpmPublicationState({
+      expectedName,
+      expectedVersion,
+      expectedIntegrity,
+      timeoutMs,
+    });
+    process.stdout.write(`${state}\n`);
+  } else {
+    if (mode !== "verify") {
+      throw new Error(`unsupported NPM_RELEASE_MODE: ${mode}`);
+    }
+    if (!/^[0-9a-f]{40}$/.test(expectedSourceCommit || "")) {
+      throw new Error(
+        "a 40-character NPM_RELEASE_EXPECTED_SOURCE_COMMIT is required in verify mode",
+      );
+    }
+
+    const attempts = Number(process.env.NPM_RELEASE_ATTEMPTS || 12);
+    const delayMs = Number(process.env.NPM_RELEASE_DELAY_MS || 5_000);
+    if (!Number.isInteger(attempts) || attempts < 1) {
+      throw new Error("NPM_RELEASE_ATTEMPTS must be a positive integer");
+    }
+    if (!Number.isInteger(delayMs) || delayMs < 0) {
+      throw new Error("NPM_RELEASE_DELAY_MS must be a non-negative integer");
+    }
+    await verifyNpmRelease({
+      expectedName,
+      expectedVersion,
+      expectedIntegrity,
+      expectedSourceCommit,
+      attempts,
+      delayMs,
+      timeoutMs,
+    });
+    process.stdout.write(
+      `npm latest integrity and source-bound SLSA provenance verified for ${expectedName}@${expectedVersion}.\n`,
+    );
+  }
 }

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/OilpriceAPI/mcp-server",
     "source": "github"
   },
-  "version": "3.2.1",
+  "version": "3.2.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "oilpriceapi-mcp",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/directorySource.test.ts
+++ b/src/__tests__/directorySource.test.ts
@@ -139,6 +139,11 @@ describe("directory-facing source metadata", () => {
     expect(npmPublishJob).toContain('node "$NPM_CLI" publish');
     expect(npmPublishJob).toContain("NPM_RELEASE_EXPECTED_INTEGRITY");
     expect(npmPublishJob).toContain("NPM_RELEASE_EXPECTED_SOURCE_COMMIT");
+    expect(npmPublishJob).toContain("NPM_RELEASE_MODE=publication-state");
+    expect(npmPublishJob).not.toMatch(
+      /\b(?:npm|NPM_CLI)\b[^\n]*\bview\b/,
+    );
+    expect(npmPublishJob).not.toContain("|| true");
     expect(npmPublishJob).toContain("node verify-npm-release.mjs");
     expect(verifyJob).toContain('npm pack "npm@$NPM_CLI_VERSION"');
     expect(verifyJob).toContain("$NPM_CLI_INTEGRITY");

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export {
 // API Configuration
 const API_BASE =
   process.env.OILPRICEAPI_BASE_URL || "https://api.oilpriceapi.com";
-export const MCP_VERSION = "3.2.1";
+export const MCP_VERSION = "3.2.2";
 export const CLIENT_MARKER = `oilpriceapi-mcp/${MCP_VERSION}`;
 export const USER_AGENT = CLIENT_MARKER;
 


### PR DESCRIPTION
## Summary
- replace the release job's fail-open `npm view ... || true` recovery branch with a built-in typed npm Registry resolver
- treat only an exact HTTP 404 as unpublished; require exact package/version/integrity for an existing version; fail on malformed, conflicting, unavailable, or unexpected responses
- bump every governed release surface to immutable recovery version `3.2.2`

## Why
The immutable `v3.2.1` release run stopped before publication because npm's E404 JSON body was coerced into a nonempty integrity string. npm and the MCP Registry remain unpublished at 3.2.1. The tag/release is retained and marked publication-halted.

## TDD proof
RED:
- `node scripts/verify-npm-release-smoke.mjs` failed because `resolveNpmPublicationState` did not exist
- workflow contract rejected the existing `npm view ... || true` branch

GREEN at exact head `804961c181aa29ef0a0f90761a44f7c1d73f2569`:
- `npm test`: 193 passed
- `npm audit --audit-level=low`: 0 vulnerabilities
- npm, MCP Registry, and protected-main provenance verifier smokes: green
- release metadata `3.2.2`: green
- public-claims: 46 source/packed surfaces
- product-facts source + live v1 bridge: green, reviewed `50/day`
- packed CLI/capabilities/scopes/protocol: green
- deterministic non-root Docker smoke: green, exact source `804961c1`
- live exact npm publication-state request for absent `oilpriceapi-mcp@3.2.2`: `absent`, exit 0
- `git diff --check`: clean

## Release gates
- no npm or MCP Registry publication occurs from this PR
- after merge, require exact-main CI and credentialed production synthetic
- publish immutable `v3.2.2`, then verify npm latest/integrity/SLSA provenance, MCP Registry exact readback, and cold-installed keyless customer paths
- downstream API v2/docs/Sheets rollout remains held until those public artifact checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the MCP server and package version to **3.2.2** across the published configuration and metadata.

- **Bug Fixes**
  - Improved npm publishing validation to distinguish already-published, unpublished, and invalid package states.
  - Prevented releases from proceeding when registry responses are ambiguous, malformed, or inconsistent.

- **Tests**
  - Added coverage for successful, missing, invalid, and server-error registry responses.
  - Strengthened checks for secure publication workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->